### PR TITLE
added condor queue selection and normalErrs, fixed hadd multithreading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PlotsConfigurationsRun3"]
+	path = PlotsConfigurationsRun3
+	url = git@github.com:latinos/PlotsConfigurationsRun3.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "PlotsConfigurationsRun3"]
-	path = PlotsConfigurationsRun3
-	url = git@github.com:latinos/PlotsConfigurationsRun3.git

--- a/install.sh
+++ b/install.sh
@@ -15,10 +15,10 @@ cat << EOF > start.sh
 #!/bin/bash
 $sourceCommand
 source `pwd`/myenv/bin/activate
+export STARTPATH=`pwd`/start.sh
 EOF
 
 chmod +x start.sh
-
 
 wget https://gpizzati.web.cern.ch/mkShapesRDF/jsonpog-integration.tar.gz
 tar -xzvf jsonpog-integration.tar.gz

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -102,6 +102,14 @@ def defaultParser():
         required=False,
         default="0",
     )
+    parser.add_argument(
+        "-q",
+        "--queue",
+        choices=['espresso', 'microcentury', 'longlunch', 'workday', 'tomorrow', 'testmatch'],
+        help="Condor queue",
+        required=False,
+        default="workday",
+    )
     return parser
 
 
@@ -113,6 +121,7 @@ def main():
     operationMode = args.operationMode
     doBatch = int(args.doBatch)
     dryRun = int(args.dryRun)
+    queue = args.queue
     global folder
     folder = os.path.abspath(args.folder)
     configsFolder = os.path.abspath(args.folder + "/" + args.configsFolder)
@@ -279,6 +288,11 @@ def main():
         Warning in <Snapshot>: A lazy Snapshot action was booked but never triggered.
         cling::DynamicLibraryManager::loadLibrary(): libOpenGL.so.0: cannot open shared object file: No such file or directory
         Error in <AutoloadLibraryMU>: Failed to load library /cvmfs/sft.cern.ch/lcg/releases/ROOT/6.28.00
+        TClass::Init:0: RuntimeWarning: no dictionary for class edm::Hash<1> is available
+        TClass::Init:0: RuntimeWarning: no dictionary for class edm::ParameterSetBlob is available
+        TClass::Init:0: RuntimeWarning: no dictionary for class edm::ProcessHistory is available
+        TClass::Init:0: RuntimeWarning: no dictionary for class edm::ProcessConfiguration is available
+        TClass::Init:0: RuntimeWarning: no dictionary for class pair<edm::Hash<1>,edm::ParameterSetBlob> is available         
         """
         normalErrs = normalErrs.split("\n")
         normalErrs = list(map(lambda k: k.strip(" ").strip("\t"), normalErrs))
@@ -319,7 +333,7 @@ def main():
             if resubmit == 1:
                 from mkShapesRDF.shapeAnalysis.BatchSubmission import BatchSubmission
 
-                BatchSubmission.resubmitJobs(batchFolder, tag, toResubmit, dryRun)
+                BatchSubmission.resubmitJobs(batchFolder, tag, toResubmit, dryRun, queue)
 
         if resubmit == 2:
             # resubmit all the jobs that are not finished
@@ -327,7 +341,7 @@ def main():
             print(toResubmit)
             from mkShapesRDF.shapeAnalysis.BatchSubmission import BatchSubmission
 
-            BatchSubmission.resubmitJobs(batchFolder, tag, toResubmit, dryRun)
+            BatchSubmission.resubmitJobs(batchFolder, tag, toResubmit, dryRun, queue)
 
     elif operationMode == 2:
         print(
@@ -353,7 +367,7 @@ def main():
 
         print(f"Hadding files into {folder}/{outputFolder}/{outputFile}")
         process = subprocess.Popen(
-            f'hadd -j {folder}/{outputFolder}/{outputFile} {" ".join(filesToMerge)}',
+            f'hadd -j 10 {folder}/{outputFolder}/{outputFile} {folder}/{outputFolder}/{outputFileTrunc}__ALL__*.root',
             shell=True,
         )
         process.wait()

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -236,7 +236,7 @@ def main():
                 batchVars,
             )
             batch.createBatches()
-            batch.submit(dryRun)
+            batch.submit(dryRun, queue)
 
         else:
             print("#" * 20, "\n\n", " Running on local machine  ", "\n\n", "#" * 20)

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -367,7 +367,9 @@ def main():
 
         print(f"Hadding files into {folder}/{outputFolder}/{outputFile}")
         process = subprocess.Popen(
-            f'hadd -j 10 {folder}/{outputFolder}/{outputFile} {folder}/{outputFolder}/{outputFileTrunc}__ALL__*.root',
+            f'echo {" ".join(filesToMerge)} > filesToMerge_{outputFile}.txt; \
+            while read line; do hadd -j 10 {folder}/{outputFolder}/{outputFile} $line; done < filesToMerge_{outputFile}.txt; \
+            rm filesToMerge_{outputFile}.txt',
             shell=True,
         )
         process.wait()

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -366,11 +366,11 @@ def main():
         print("\n\n", filesToMerge, "\n\n")
 
         print(f"Hadding files into {folder}/{outputFolder}/{outputFile}")
+        for fileToMerge in filesToMerge:
+          os.system(f'echo {fileToMerge} >> filesToMerge_{outputFile}.txt')
         process = subprocess.Popen(
-            fr"echo {' '.join(filesToMerge)} > filesToMerge_{outputFile}.txt; \
-            sed -i 's/\ /\n/g' filesToMerge_{outputFile}.txt; \
-            hadd -j 10 {folder}/{outputFolder}/{outputFile} @filesToMerge_{outputFile}.txt; \
-            rm filesToMerge_{outputFile}.txt",
+            f'hadd -j 10 {folder}/{outputFolder}/{outputFile} @filesToMerge_{outputFile}.txt; \
+            rm filesToMerge_{outputFile}.txt',
             shell=True,
         )
         process.wait()

--- a/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
+++ b/mkShapesRDF/shapeAnalysis/mkShapesRDF.py
@@ -367,9 +367,10 @@ def main():
 
         print(f"Hadding files into {folder}/{outputFolder}/{outputFile}")
         process = subprocess.Popen(
-            f'echo {" ".join(filesToMerge)} > filesToMerge_{outputFile}.txt; \
-            while read line; do hadd -j 10 {folder}/{outputFolder}/{outputFile} $line; done < filesToMerge_{outputFile}.txt; \
-            rm filesToMerge_{outputFile}.txt',
+            fr"echo {' '.join(filesToMerge)} > filesToMerge_{outputFile}.txt; \
+            sed -i 's/\ /\n/g' filesToMerge_{outputFile}.txt; \
+            hadd -j 10 {folder}/{outputFolder}/{outputFile} @filesToMerge_{outputFile}.txt; \
+            rm filesToMerge_{outputFile}.txt",
             shell=True,
         )
         process.wait()

--- a/mkShapesRDF/shapeAnalysis/runner.py
+++ b/mkShapesRDF/shapeAnalysis/runner.py
@@ -264,7 +264,7 @@ class RunAnalysis:
                 df = ROOT.RDataFrame(tnom)
                 df = df.Range(limit)
             else:
-                ROOT.EnableImplicitMT()
+                #ROOT.EnableImplicitMT()
                 df = ROOT.RDataFrame(tnom)
             if sampleName not in self.dfs.keys():
                 self.dfs[sample[0]] = {}


### PR DESCRIPTION
Ciao @giorgiopizz , @dittmer , @NTrevisani 

I've added a small set of features, like the possibilty to select the job flavour queue and change it back when resubmitting failed jobs (-q option, default is "workday"). Standard printout obtained when a macro is compiled is not interpreted as an error anymore, and the hadd step now runs over 10 cores (hard-coded, but it can be easily put as an option if needed). Moreover, I've commented out the implicitMT RDF mode, which I don't think is needed when jobs are submitted to condor and sometimes it causes troubles. Finally, an auxiliary variable is set when the code is installed, which points to the "start.sh" script, without assuming any relative path. This is important, because, as of now, configurations in batch mode only work if they're two levels below where the start.sh is located, which is not ideal (see https://github.com/latinos/mkShapesRDF/blob/master/mkShapesRDF/shapeAnalysis/BatchSubmission.py#L114).

Please have a look at it, and let me know if you have some feedback/way to improve these features - assuming they're not bugs 
Cheers,
Mattia