### PR TITLE
runner re-styling and other fixes

### DIFF
--- a/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
+++ b/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
@@ -96,7 +96,6 @@ def update_variables_with_categories(variables, categoriesmap):
             # otherwise we replace the cut with all the categories
             cutspec.extend(categories)
 
-
 def update_nuisances_with_subsamples(nuisances, subsamplesmap):
     """
     Update nuisances dict with the flatten subsamples.
@@ -108,7 +107,7 @@ def update_nuisances_with_subsamples(nuisances, subsamplesmap):
     subsamplesmap : list
         subsamplesmap as returned by flatten_samples
     """
-    for nuisance in nuisances.items():
+    for _,nuisance in nuisances.items():
         if "samples" not in nuisance:
             continue
 
@@ -159,3 +158,37 @@ def update_nuisances_with_categories(nuisances, categoriesmap):
 
             # otherwise we replace the cut with all the categories
             cutspec.extend(categories)
+
+def update_aliases_with_subsamples(aliases, subsamplesmap, samples):
+    """
+    Update aliases dict with the flatten subsamples.
+
+    Parameters
+    ----------
+    aliases : dict
+        aliases dictionary, will be modified in place
+    subsamplesmap : list
+        subsamplesmap as returned by flatten_samples
+    samples : dict
+        samples dictionary, used to assign its keys to aliases that do not specify any sample
+    """
+    parents     = [parent[0] for parent in subsamplesmap]
+    children    = [children[1] for children in subsamplesmap]
+    for _,alias in aliases.items():
+        if "samples" not in alias:
+            alias["samples"] = samples.keys()
+            for parent in parents:
+                if parent in alias["samples"]:
+                    alias["sample"] .remove(parent)
+                    alias["sample"] += children
+            continue
+
+        samplespec = alias["samples"]
+
+        for sname, subsamples in subsamplesmap:
+            if sname not in samplespec:
+                continue
+            else:
+                samplespec.remove(sname)
+                samplespec += subsamples
+

--- a/mkShapesRDF/shapeAnalysis/rnp.py
+++ b/mkShapesRDF/shapeAnalysis/rnp.py
@@ -21,7 +21,7 @@ def rnp_array(array, copy=True):
         converted numpy array
     """
     if not isinstance(array, ROOT.TArrayD):
-        raise ("Cannot convert ", array, "to TArrayD")
+        raise ValueError("Cannot convert ", array, "to TArrayD")
     dtype = np.double
     nx = len(array)
     arr = np.ndarray((nx,), dtype=dtype, buffer=array.GetArray())

--- a/mkShapesRDF/shapeAnalysis/runner.py
+++ b/mkShapesRDF/shapeAnalysis/runner.py
@@ -442,11 +442,8 @@ class RunAnalysis:
                     map(lambda k: str(k), df1.GetColumnNames())
                 )
                 
-                # Since it is not possible to define a DATA-dependent weight through aliases - DATA are not divided 
-                # by subsamples but rather by trigger selection - we must remove the alias weight each time, as its 
-                # value depends on the trigger selection.
-                if isData:
-                    del self.aliases["weight"]
+                # Clear alias weight
+                del self.aliases["weight"]
 
 
     def loadSystematics(self):


### PR DESCRIPTION
This PR is meant to apply some resyling to the mkShapesRDF runner and other fixes:

1. splitSamples is internally called by RunAnalysis, such as inputs are the python dictionaries defined in a given configuration
2. script.py contains the samples dictionary rather than the splitSample tuple
3. aliases, samples and nuisances files are updated on-the-fly, such as subsamples are correctly propragated. Now it is possible to define aliases and nuisances per subsample; if only the parent name is given, they will be extended to each subsample - if any
4. runner.py loads all aliases at once and all systematics (shape) variations are computed afterwards. Variations are correctly propragated to each variable
5. input histograms that are used to compute envelopes are not removed during the hadd step, as this was causing a noticeable slowdown
