### PR TITLE
Changed flatten subsample behaviour not working on batch

### DIFF
--- a/docs/shapes/python/samples.py
+++ b/docs/shapes/python/samples.py
@@ -90,10 +90,12 @@ Examples
 >>>     + "*( !(Sum(PhotonGen_isPrompt==1 && PhotonGen_pt>15 && abs(PhotonGen_eta)<2.6) > 0)) * ewknloW",
 >>>     "FilesPerJob": 5,
 >>>     "subsamples": dys,
->>>     "flatten_samples_map": lambda sname, sub: "%s" % (sub) 
->>>     # in this way flatten sampled are simply "DY_hardJets", "DY_PUJets", 
->>>     # and "DY_inclusive_rwgt"
->>>     # default flatten_samples_map is lambda sname, sub: '%s_%s' % (sname, sub)
+>>>     "flatten_samples_map": 1 
+>>>     # By default (flatten_samples_map=0), subsamples will carry the sample
+>>>     # name as prefix (e.g. DY_DY_hardJets, DY_DY_PUJets, ...). By specifying 
+>>>     # flatten_samples_map=1 the sample prefix will be dropped and subsamples
+>>>     # names will be the one appearing in the subsamples dictionary keys 
+>>>     # (for this example subsample shape names will be DY_hardJets, DY_PUJets)
 >>> }
 
 

--- a/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
+++ b/mkShapesRDF/shapeAnalysis/latinos/LatinosUtils.py
@@ -17,10 +17,12 @@ def flatten_samples(samples):
         sample = samples[sname]
         if "subsamples" not in sample:
             continue
-        flatten_samples_map = samples[sname].get(
-            "flatten_samples_map", lambda sname, sub: "%s_%s" % (sname, sub)
+        active_fsm = samples[sname].get(
+            "flatten_samples_map", 0
         )
-
+        if active_fsm == 0:  flatten_samples_map = lambda sname, sub: "%s_%s" % (sname, sub)
+        else: flatten_samples_map = lambda sname, sub: "%s" % (sub)
+        
         subsamplesmap.append((sname, []))
         for sub in sample["subsamples"]:
             new_subsample_name = flatten_samples_map(sname, sub)

--- a/mkShapesRDF/shapeAnalysis/runner.py
+++ b/mkShapesRDF/shapeAnalysis/runner.py
@@ -854,9 +854,13 @@ class RunAnalysis:
             _sample = list(filter(lambda k: k[0] == sampleName, self.samples))[0]
             for subsample in list(_sample[6].keys()):
                 # _sample[5] is the original dict, i.e. samples[sampleName]
-                flatten_samples_map = _sample[5].get(
-                    "flatten_samples_map", lambda sname, sub: "%s_%s" % (sname, sub)
+                
+                active_fsm = _sample[5].get(
+                    "flatten_samples_map", 0
                 )
+                if active_fsm == 0:  flatten_samples_map = lambda sname, sub: "%s_%s" % (sname, sub)
+                else: flatten_samples_map = lambda sname, sub: "%s" % (sub)
+                
                 new_subsample_name = flatten_samples_map(sampleName, subsample)
                 self.dfs[new_subsample_name] = {}
                 for index in self.dfs[sampleName].keys():


### PR DESCRIPTION
The flatten subsample implementation with lambda functions was cryptic and was not working in batch mode.
Now it is turned into a simple flag that can be specified in the samples dictionary. If the value is 0 then one recovers the normal behaviour, prepending the sample name to the subsample one. If 1 is specified, the sample name is dropped. 
This fix is sufficient and covers all cases as user are free to specify whatever subsample name.

Both local and batch execution have been tested successfully.

Example docs updated.

Note: it was raised some months ago that nuisances could not be applied to only specific subsamples (it was either all of them or none of them). Now it is possible (at least for weight type uncertainties) to compute them only on a set of subsamples. I do not know if this feature was implemented before but it is worth reminding it in this PR. 