### PR TITLE
Update install.sh to be almalinux:9 machines compliant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ if [ -z "$1" ]; then
     if [[ "$OS" == *"centos:7"* ]]; then
         echo centos7
         sourceCommand="$sourceCommand""; source /cvmfs/sft.cern.ch/lcg/views/LCG_105/x86_64-centos7-gcc11-opt/setup.sh"
-    elif [[ "$OS" == *"enterprise_linux:9"* ]]; then
+    elif [[ "$OS" == *"linux:9"* ]]; then
         echo el9
         sourceCommand="$sourceCommand""; source /cvmfs/sft.cern.ch/lcg/views/LCG_105/x86_64-el9-gcc11-opt/setup.sh"
     else


### PR DESCRIPTION
removed "enterprise_" to make the installation work in other machines like `CPE OS Name: cpe:/o:almalinux:almalinux:9::baseos` (e.g. KIT machines)