### PR TITLE
Fix for ttHMVA module

### DIFF
--- a/mkShapesRDF/processor/data/ttH-Run3-LeptonMVA/Electron_tthMVAFiller.cc
+++ b/mkShapesRDF/processor/data/ttH-Run3-LeptonMVA/Electron_tthMVAFiller.cc
@@ -41,6 +41,7 @@ public:
     
     reader = new TMVA::Reader( "!Color:Silent" );
 
+    /* commenting out unneded spectators
     reader->AddSpectator("event", &event);
     reader->AddSpectator("Electron_mvaTTH", &Electron_mvaTTH);
     reader->AddSpectator("Electron_miniPFRelIso_all", &Electron_miniPFRelIso_all);
@@ -49,6 +50,7 @@ public:
     reader->AddSpectator("Electron_genPartFlav", &Electron_genPartFlav);
     reader->AddSpectator("Electron_dxy", &Electron_dxy);
     reader->AddSpectator("Electron_dz", &Electron_dz);
+    */
 
     reader->AddVariable("Electron_pt",                                                                                &electron_pt);
     reader->AddVariable("Electron_eta",                                                                               &electron_eta);
@@ -57,8 +59,8 @@ public:
     reader->AddVariable("Electron_miniRelIsoNeutral := Electron_miniPFRelIso_all - Electron_miniPFRelIso_chg",        &electron_miniRelIsoNeutral);
     reader->AddVariable("Electron_jetNDauCharged",                                                                    &electron_jetNDauCharged);
     reader->AddVariable("Electron_jetPtRelv2",                                                                        &electron_jetPtRelv2);
-    reader->AddVariable("Electron_jetPtRatio := min(1 / (1 + Electron_jetRelIso), 1.5)",                              &electron_jetPtRatio);
     reader->AddVariable("Electron_jetBTagDeepFlavB := Electron_jetIdx > -1 ? Jet_btagDeepFlavB[Electron_jetIdx] : 0", &electron_jetBTagDeepFlavB);
+    reader->AddVariable("Electron_jetPtRatio := min(1 / (1 + Electron_jetRelIso), 1.5)",                              &electron_jetPtRatio);
     reader->AddVariable("Electron_sip3d",                                                                             &electron_sip3d);
     reader->AddVariable("Electron_log_dxy := log(abs(Electron_dxy))",                                                 &electron_log_dxy);
     reader->AddVariable("Electron_log_dz  := log(abs(Electron_dz))",                                                  &electron_log_dz);

--- a/mkShapesRDF/processor/data/ttH-Run3-LeptonMVA/Muon_tthMVAFiller.cc
+++ b/mkShapesRDF/processor/data/ttH-Run3-LeptonMVA/Muon_tthMVAFiller.cc
@@ -44,6 +44,7 @@ public:
     
     reader = new TMVA::Reader( "!Color:Silent" );
 
+    /* commenting out unneded spectators
     reader->AddSpectator("event", &event);
     reader->AddSpectator("Muon_mvaTTH", &Muon_mvaTTH);
     reader->AddSpectator("Muon_miniPFRelIso_all", &Muon_miniPFRelIso_all);
@@ -56,6 +57,7 @@ public:
     reader->AddSpectator("Muon_looseId", &Muon_looseIdBis);
     reader->AddSpectator("Muon_dxy", &Muon_dxy);
     reader->AddSpectator("Muon_dz", &Muon_dz);
+    */
     
     reader->AddVariable("Muon_pt",                                                                                &muon_pt);
     reader->AddVariable("Muon_eta",                                                                               &muon_eta);
@@ -64,8 +66,8 @@ public:
     reader->AddVariable("Muon_miniRelIsoNeutral := Muon_miniPFRelIso_all - Muon_miniPFRelIso_chg",                &muon_miniRelIsoNeutral);
     reader->AddVariable("Muon_jetNDauCharged",                                                                    &muon_jetNDauCharged);
     reader->AddVariable("Muon_jetPtRelv2",                                                                        &muon_jetPtRelv2);
-    reader->AddVariable("Muon_jetPtRatio := min(1 / (1 + Muon_jetRelIso), 1.5)",                                  &muon_jetPtRatio);
     reader->AddVariable("Muon_jetBTagDeepFlavB := Muon_jetIdx > -1 ? Jet_btagDeepFlavB[Muon_jetIdx] : 0",         &muon_jetBTagDeepFlavB);
+    reader->AddVariable("Muon_jetPtRatio := min(1 / (1 + Muon_jetRelIso), 1.5)",                                  &muon_jetPtRatio);
     reader->AddVariable("Muon_sip3d",                                                                             &muon_sip3d);
     reader->AddVariable("Muon_log_dxy := log(abs(Muon_dxy))",                                                     &muon_log_dxy);
     reader->AddVariable("Muon_log_dz  := log(abs(Muon_dz))",                                                      &muon_log_dz);

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -508,7 +508,7 @@ Steps = {
         "do4MC": True,
         "do4Data": True,
         "import": "mkShapesRDF.processor.modules.LeptonFiller_ttHMVA",
-        "declare": 'leptonFill_tthMVA = lambda : LeptonFiller_ttHMVA("RPLME_FW/processor/data/ttH-Run3-LeptonMVA/")',
+        "declare": 'leptonFill_tthMVA = lambda : LeptonFiller_ttHMVA("RPLME_FW/processor/data/ttH-Run3-LeptonMVA", "Muon-mvaTTH.2022EE.weights.xml", "Electron-mvaTTH.2022EE.weights_mvaISO.xml)',
         "module": "leptonFill_tthMVA()",
     },
     "lepSel": {

--- a/mkShapesRDF/processor/modules/LeptonFiller_ttHMVA.py
+++ b/mkShapesRDF/processor/modules/LeptonFiller_ttHMVA.py
@@ -5,9 +5,11 @@ import correctionlib
 correctionlib.register_pyroot_binding()
 
 class LeptonFiller_ttHMVA(Module):
-    def __init__(self, script_path="processor/data/ttH-Run3-LeptonMVA/"):
+    def __init__(self, script_path="processor/data/ttH-Run3-LeptonMVA", mu_xml="Muon-mvaTTH.2022EE.weights.xml", ele_xml="Electron-mvaTTH.2022EE.weights_mvaISO.xml"):
         super().__init__("LeptonFiller_ttHMVA")
         self.script_path = script_path
+        self.mu_xml = mu_xml
+        self.ele_xml = ele_xml
         
     def runModule(self, df, values):
 
@@ -29,10 +31,10 @@ class LeptonFiller_ttHMVA(Module):
             )
         
         ROOT.gROOT.ProcessLineSync(f".L {self.script_path}/Muon_tthMVAFiller.cc+")
-        ROOT.gInterpreter.Declare(f'Muon_tthMVAFiller evaluateTTH_muon("{self.script_path}");')
+        ROOT.gInterpreter.Declare(f'Muon_tthMVAFiller evaluateTTH_muon("{self.script_path}/{self.mu_xml}");')
 
         ROOT.gROOT.ProcessLineSync(f".L {self.script_path}/Electron_tthMVAFiller.cc+")
-        ROOT.gInterpreter.Declare(f'Electron_tthMVAFiller evaluateTTH_electron("{self.script_path}");')
+        ROOT.gInterpreter.Declare(f'Electron_tthMVAFiller evaluateTTH_electron("{self.script_path}/{self.ele_xml}");')
         
         if "Muon_log_dxy" not in df.GetColumnNames():
             df = df.Define("Muon_miniRelIsoNeutral", "Muon_miniPFRelIso_all - Muon_miniPFRelIso_chg")


### PR DESCRIPTION
Here's a quick fix for the ttHMVA module:
- XML files were not included in the module, which just pointed to the upper-level folder, causing mkShapesRDF to run indefinitely
- The variables order now matches what's inside the XML file, which is needed by TMVA
- XML files are provided as additional arguments of the module, making it configurable in the Steps_cfg.py

@BlancoFS @NTrevisani @dittmer 