### PR TITLE
Analysis recipes

### DIFF
--- a/mkShapesRDF/processor/data/LeptonSel_cfg.py
+++ b/mkShapesRDF/processor/data/LeptonSel_cfg.py
@@ -618,6 +618,21 @@ MuonWP = {
             },
         },
         "TightObjWP": {
+            "cut_TightID_POG": {
+                "cuts": {
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_tightId",
+                    ],
+                },
+                "idSF": {
+                    "1-1": ["NUM_TightID_DEN_TrackerMuons", "data/jsonpog-integration/POG/MUO/2022_Summer22/muon_Z.json.gz"],
+                },
+                "isoSF": {
+                    "1-1": ["NUM_TightPFIso_DEN_TightID", "data/jsonpog-integration/POG/MUO/2022_Summer22/muon_Z.json.gz"],
+                },
+                "fakeW": "data/fake_prompt_rates/Full2022v12/cut_Tight_HWW/",
+            },
             "cut_Tight_HWW": {
                 "cuts": {
                     "ROOT::RVecB (Muon_pt.size(), true)": [
@@ -734,6 +749,21 @@ MuonWP = {
         },
         # ------------                                                                                                                                                  
         "TightObjWP": {
+            "cut_TightID_POG": {
+                "cuts": {
+                    "ROOT::RVecB (Muon_pt.size(), true)": [
+                        "ROOT::VecOps::abs(Muon_eta) < 2.4",
+                        "Muon_tightId",
+                    ],
+                },
+                "idSF": {
+                    "1-1": ["NUM_TightID_DEN_TrackerMuons", "data/jsonpog-integration/POG/MUO/2022_Summer22EE/muon_Z.json.gz"],
+                },
+                "isoSF": {
+                    "1-1": ["NUM_TightPFIso_DEN_TightID", "data/jsonpog-integration/POG/MUO/2022_Summer22EE/muon_Z.json.gz"],
+                },
+                "fakeW": "data/fake_prompt_rates/Full2022EEv12/cut_Tight_HWW/",
+            },
             "cut_Tight_HWW": {
                 "cuts": {
                     # Common cuts                                                                                                                                       

--- a/mkShapesRDF/processor/framework/.tests/dumpMuSFTable.py
+++ b/mkShapesRDF/processor/framework/.tests/dumpMuSFTable.py
@@ -8,7 +8,7 @@ if len(sys.argv) < 3:
 
 df = ROOT.RDataFrame("Events", sys.argv[1])
 
-cols = df.Define("MuonIdSFProd", "ROOT::VecOps::Product(Lepton_tightMuon_cut_TightID_POG_NOISO_idSF)")\
+cols = df.Define("MuonIdSFProd", "ROOT::VecOps::Product(Lepton_tightMuon_cut_TightID_POG_idSF)")\
          .AsNumpy(["event", "run", "luminosityBlock", "MuonIdSFProd"])
 
 out = np.column_stack((cols['event'], cols['run'], cols['luminosityBlock'], cols['MuonIdSFProd']))

--- a/mkShapesRDF/processor/framework/.tests/dumpMuSFTable.py
+++ b/mkShapesRDF/processor/framework/.tests/dumpMuSFTable.py
@@ -1,0 +1,15 @@
+import ROOT
+import numpy as np
+
+import sys
+
+if len(sys.argv) < 3:
+    print ("usage: python dumpMuSFTable.py filename.root outfile.txt")
+
+df = ROOT.RDataFrame("Events", sys.argv[1])
+
+cols = df.Define("MuonIdSFProd", "ROOT::VecOps::Product(Lepton_tightMuon_cut_TightID_POG_NOISO_idSF)")\
+         .AsNumpy(["event", "run", "luminosityBlock", "MuonIdSFProd"])
+
+out = np.column_stack((cols['event'], cols['run'], cols['luminosityBlock'], cols['MuonIdSFProd']))
+np.savetxt(sys.argv[2], out, delimiter=',', fmt='%i,%i,%i,%1.6f')

--- a/mkShapesRDF/processor/framework/Productions_cfg.py
+++ b/mkShapesRDF/processor/framework/Productions_cfg.py
@@ -155,7 +155,7 @@ Productions = {
     "Summer22EE_130x_nAODv12_Full2022v12_testrecipes": {
         "isData": False,
         "samples": "../framework/samples/Summer22EE_130x_nAODv12_testrecipes.py",
-        "cmssw": "Full2022v12",
+        "cmssw": "Full2022EEv12",
         "year": "2022",
         "xsFile": "../framework/samples/samplesCrossSections_13p6TeV.py",
         "YRver": ["YR4", "13p6TeV"],

--- a/mkShapesRDF/processor/framework/Productions_cfg.py
+++ b/mkShapesRDF/processor/framework/Productions_cfg.py
@@ -152,4 +152,12 @@ Productions = {
         "xsFile": "../framework/samples/samplesCrossSections_13p6TeV.py",
         "YRver": ["YR4", "13p6TeV"],
     },
+    "Summer22EE_130x_nAODv12_Full2022v12_testrecipes": {
+        "isData": False,
+        "samples": "../framework/samples/Summer22EE_130x_nAODv12_testrecipes.py",
+        "cmssw": "Full2022v12",
+        "year": "2022",
+        "xsFile": "../framework/samples/samplesCrossSections_13p6TeV.py",
+        "YRver": ["YR4", "13p6TeV"],
+    },
 }

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -1010,6 +1010,19 @@ Steps = {
     ###
     ### Full set of corrections for Run2022E+FG Prompt : Summer22EE MC campaign
     ###
+    "MCCorr2022EEv12_testrecipes": {
+        "isChain": True,
+        "do4MC": True,
+        "do4Data": False,
+        "selection": '"((nElectron+nMuon)>=0)"',
+        "subTargets": [
+            "leptonMaker_nofilter",
+            "lepSel_Summer22",
+            "trigMC_2022EE",
+            "leptonSF_Summer22",
+            "finalSnapshot_MC"
+        ]
+    },
     "MCl1loose2022EEv12__MCCorr2022EEv12__l2tight": {
         "isChain": True,
         "do4MC": True,
@@ -1169,7 +1182,14 @@ Steps = {
         "declare": "leptonMaker = lambda : LeptonMaker()",
         "module": "leptonMaker()",
     },
-
+	"leptonMaker_nofilter": {
+        "isChain": False,
+        "do4MC": True,
+        "do4Data": True,
+        "import": "mkShapesRDF.processor.modules.LeptonMaker",
+        "declare": "leptonMaker = lambda : LeptonMaker(min_lep_pt=0.)",
+        "module": "leptonMaker()",
+    },
     "lepFiller_hwwMVA": {
         "isChain": False,
         "do4MC": True,

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -1182,7 +1182,7 @@ Steps = {
         "declare": "leptonMaker = lambda : LeptonMaker()",
         "module": "leptonMaker()",
     },
-	"leptonMaker_nofilter": {
+    "leptonMaker_nofilter": {
         "isChain": False,
         "do4MC": True,
         "do4Data": True,
@@ -1416,6 +1416,7 @@ Steps = {
         "declare": "LeptonSS = lambda : LeptonScaleSmearing('RPLME_CMSSW', False, 'RPLME_FW')",
         "module": "LeptonSS()",
     },
+    
     "formulasDATA": {
         "isChain": False,
         "do4MC": False,

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -1017,9 +1017,9 @@ Steps = {
         "selection": '"((nElectron+nMuon)>=0)"',
         "subTargets": [
             "leptonMaker_nofilter",
-            "lepSel_Summer22",
+            "lepSel_Summer22EE_testrecipes",
             "trigMC_2022EE",
-            "leptonSF_Summer22",
+            "leptonSF_Summer22EE",
             "finalSnapshot_MC"
         ]
     },
@@ -1217,6 +1217,14 @@ Steps = {
         "declare": 'leptonSel = lambda : LeptonSel("Loose", 1, "RPLME_CMSSW")',
         "module": "leptonSel()",
     },
+    "lepSel_testrecipes":{
+        "isChain": False,
+        "do4MC": True,
+        "do4Data": True,
+        "import": "mkShapesRDF.processor.modules.LeptonSel",
+        "declare": 'leptonSel = lambda : LeptonSel("Loose", 1, "RPLME_CMSSW", False)',
+        "module": "leptonSel()",
+    },
     
     "jetSelUL": {
         "isChain": False,
@@ -1408,7 +1416,18 @@ Steps = {
         "declare": "LeptonSS = lambda : LeptonScaleSmearing('RPLME_CMSSW', False, 'RPLME_FW')",
         "module": "LeptonSS()",
     },
+<<<<<<< HEAD
 
+=======
+    "leptonSF_Summer22EE": {
+        "isChain": False,
+        "do4MC": False,
+        "do4Data": True,
+        "import": "mkShapesRDF.processor.modules.LeptonSF",
+        "declare": "leptonSF = lambda : LeptonSF('Full2022EEv12')",
+        "module": "leptonSF()",
+    },
+>>>>>>> fa07bb9 (Added the possibility in LeptonSel to disable filtering (for testing purposes). Does not change the default behavior)
     "formulasDATA": {
         "isChain": False,
         "do4MC": False,

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -1416,18 +1416,6 @@ Steps = {
         "declare": "LeptonSS = lambda : LeptonScaleSmearing('RPLME_CMSSW', False, 'RPLME_FW')",
         "module": "LeptonSS()",
     },
-<<<<<<< HEAD
-
-=======
-    "leptonSF_Summer22EE": {
-        "isChain": False,
-        "do4MC": False,
-        "do4Data": True,
-        "import": "mkShapesRDF.processor.modules.LeptonSF",
-        "declare": "leptonSF = lambda : LeptonSF('Full2022EEv12')",
-        "module": "leptonSF()",
-    },
->>>>>>> fa07bb9 (Added the possibility in LeptonSel to disable filtering (for testing purposes). Does not change the default behavior)
     "formulasDATA": {
         "isChain": False,
         "do4MC": False,

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -1010,16 +1010,17 @@ Steps = {
     ###
     ### Full set of corrections for Run2022E+FG Prompt : Summer22EE MC campaign
     ###
-    "MCCorr2022EEv12_testrecipes": {
+    "testrecipes": {
         "isChain": True,
         "do4MC": True,
         "do4Data": False,
         "selection": '"((nElectron+nMuon)>=0)"',
         "subTargets": [
             "leptonMaker_nofilter",
-            "lepSel_Summer22EE_testrecipes",
-            "trigMC_2022EE",
-            "leptonSF_Summer22EE",
+            "lepFiller_tthMVA",
+            "lepSel_testrecipes",
+            "trigMC",
+            "leptonSF",
             "finalSnapshot_MC"
         ]
     },

--- a/mkShapesRDF/processor/framework/processor.py
+++ b/mkShapesRDF/processor/framework/processor.py
@@ -118,12 +118,12 @@ class Processor:
                 }
             except KeyError:
                	d = {
-				    "process": sampleName,
+                    "process": sampleName,
                     "folder": self.Samples[sampleName]["folder"],
                     'isLatino': False
                 }
                 if self.inputFolder != "":
-                    raise RuntimeError(f"When specifying the sample via an input folder for sample {sampleName}, you cannot, at the same time, set an inputFolder")
+                     raise RuntimeError(f"When specifying the sample via an input folder for sample {sampleName}, you cannot, at the same time, set an inputFolder")
                 self.inputFolder = d['folder']
             except KeyError:
                 raise KeyError(f"You need to specify either \"nanoAOD\" or \"folder\" keys for sample {sampleName}")

--- a/mkShapesRDF/processor/framework/processor.py
+++ b/mkShapesRDF/processor/framework/processor.py
@@ -118,7 +118,7 @@ class Processor:
                 }
             except KeyError:
                	d = {
-					"process": sampleName,
+				    "process": sampleName,
                     "folder": self.Samples[sampleName]["folder"],
                     'isLatino': False
                 }

--- a/mkShapesRDF/processor/framework/processor.py
+++ b/mkShapesRDF/processor/framework/processor.py
@@ -111,10 +111,22 @@ class Processor:
         """
         if self.inputFolder == "":
             # if no inputFolder is given -> DAS
-            d = {
-                "process": self.Samples[sampleName]["nanoAOD"],
-                "instance": self.Samples[sampleName].get("instance", ""),
-            }
+            try:
+                d = {
+                    "process": self.Samples[sampleName]["nanoAOD"],
+                    "instance": self.Samples[sampleName].get("instance", ""),
+                }
+            except KeyError:
+               	d = {
+					"process": sampleName,
+                    "folder": self.Samples[sampleName]["folder"],
+                    'isLatino': False
+                }
+                if self.inputFolder != "":
+                    raise RuntimeError(f"When specifying the sample via an input folder for sample {sampleName}, you cannot, at the same time, set an inputFolder")
+                self.inputFolder = d['folder']
+            except KeyError:
+                raise KeyError(f"You need to specify either \"nanoAOD\" or \"folder\" keys for sample {sampleName}")
             if self.redirector != "":
                 d["redirector"] = self.redirector
         else:

--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12_testrecipes.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12_testrecipes.py
@@ -1,0 +1,5 @@
+Samples = {}
+
+Samples['TTTo2L2Nu_10k_nano'] = {
+    'folder': '/eos/cms/store/group/cat/datasets/recipes/2022_Summer22EE/'
+}

--- a/mkShapesRDF/processor/modules/LeptonSF.py
+++ b/mkShapesRDF/processor/modules/LeptonSF.py
@@ -692,31 +692,31 @@ class LeptonSF(Module):
                                 SFstat.push_back(sfstat);
                                 SFsyst.push_back(sfsyst);
 
-								SFid.push_back(sf_id);
-								SFid_stat.push_back(sf_idstat);
-								SFid_syst.push_back(sf_idsyst);	
+							    SFid.push_back(sf_id);
+							    SFid_stat.push_back(sf_idstat);
+							    SFid_syst.push_back(sf_idsyst);	
+    
+							    SFiso.push_back(sf_iso);
+							    SFiso_stat.push_back(sf_isostat);
+							    SFiso_syst.push_back(sf_isosyst);	
 								
-								SFiso.push_back(sf_iso);
-								SFiso_stat.push_back(sf_isostat);
-								SFiso_syst.push_back(sf_isosyst);	
-								
-								SFtth.push_back(sf_tth);
-								SFtth_stat.push_back(sf_tthstat);
-								SFtth_syst.push_back(sf_tthsyst);	
+							    SFtth.push_back(sf_tth);
+							    SFtth_stat.push_back(sf_tthstat);
+							    SFtth_syst.push_back(sf_tthsyst);	
 
                             }else{
                                 SF.push_back(1.0);
                                 SFstat.push_back(0.0);
                                 SFsyst.push_back(0.0);
-								SFid.push_back(1.0);
-								SFid_stat.push_back(0.0);
-								SFid_syst.push_back(0.0);	
-								SFiso.push_back(1.0);
-								SFiso_stat.push_back(0.0);
-								SFiso_syst.push_back(0.0);	
-								SFtth.push_back(1.0);
-								SFtth_stat.push_back(0.0);
-								SFtth_syst.push_back(0.0);	
+							    SFid.push_back(1.0);
+							    SFid_stat.push_back(0.0);
+							    SFid_syst.push_back(0.0);	
+							    SFiso.push_back(1.0);
+							    SFiso_stat.push_back(0.0);
+							    SFiso_syst.push_back(0.0);	
+							    SFtth.push_back(1.0);
+							    SFtth_stat.push_back(0.0);
+							    SFtth_syst.push_back(0.0);	
                             }
                         }
                         SFTot["total"].push_back(SF);

--- a/mkShapesRDF/processor/modules/LeptonSF.py
+++ b/mkShapesRDF/processor/modules/LeptonSF.py
@@ -637,9 +637,9 @@ class LeptonSF(Module):
                             if (abs(mu_pdgId[i])==13){
 
                                 pt = ROOT::VecOps::Max(ROOT::RVecF{ROOT::VecOps::Min(ROOT::RVecF{mu_pt[i], """
-                                + str(self.mu_maxPt)
+                                + (str(self.mu_maxPt) if "POG" not in wp else str(99999))
                                 + """}), """
-                                + str(self.mu_minPt)
+                                + (str(self.mu_minPt) if "POG" not in wp else str(15))
                                 + """}); 
                                                                                                                                                                     
                                 eta = ROOT::VecOps::Max(ROOT::RVecF{ROOT::VecOps::Min(ROOT::RVecF{mu_eta[i], """
@@ -692,31 +692,31 @@ class LeptonSF(Module):
                                 SFstat.push_back(sfstat);
                                 SFsyst.push_back(sfsyst);
 
-							    SFid.push_back(sf_id);
-							    SFid_stat.push_back(sf_idstat);
-							    SFid_syst.push_back(sf_idsyst);	
+                                SFid.push_back(sf_id);
+                                SFid_stat.push_back(sf_idstat);
+                                SFid_syst.push_back(sf_idsyst);	
     
-							    SFiso.push_back(sf_iso);
-							    SFiso_stat.push_back(sf_isostat);
-							    SFiso_syst.push_back(sf_isosyst);	
-								
-							    SFtth.push_back(sf_tth);
-							    SFtth_stat.push_back(sf_tthstat);
-							    SFtth_syst.push_back(sf_tthsyst);	
+                                SFiso.push_back(sf_iso);
+                                SFiso_stat.push_back(sf_isostat);
+                                SFiso_syst.push_back(sf_isosyst);	
+
+                                SFtth.push_back(sf_tth);
+                                SFtth_stat.push_back(sf_tthstat);
+                                SFtth_syst.push_back(sf_tthsyst);	
 
                             }else{
                                 SF.push_back(1.0);
                                 SFstat.push_back(0.0);
                                 SFsyst.push_back(0.0);
-							    SFid.push_back(1.0);
-							    SFid_stat.push_back(0.0);
-							    SFid_syst.push_back(0.0);	
-							    SFiso.push_back(1.0);
-							    SFiso_stat.push_back(0.0);
-							    SFiso_syst.push_back(0.0);	
-							    SFtth.push_back(1.0);
-							    SFtth_stat.push_back(0.0);
-							    SFtth_syst.push_back(0.0);	
+                                SFid.push_back(1.0);
+                                SFid_stat.push_back(0.0);
+                                SFid_syst.push_back(0.0);	
+                                SFiso.push_back(1.0);
+                                SFiso_stat.push_back(0.0);
+                                SFiso_syst.push_back(0.0);	
+                                SFtth.push_back(1.0);
+                                SFtth_stat.push_back(0.0);
+                                SFtth_syst.push_back(0.0);	
                             }
                         }
                         SFTot["total"].push_back(SF);

--- a/mkShapesRDF/processor/modules/LeptonSF.py
+++ b/mkShapesRDF/processor/modules/LeptonSF.py
@@ -585,14 +585,27 @@ class LeptonSF(Module):
 
             ROOT.gInterpreter.Declare(
                 """
-                    std::vector<ROOT::RVecF> getSF_"""
+                    std::map<std::string, std::vector<ROOT::RVecF> > getSF_"""
                     + wp
                     + """_Muon(ROOT::RVecF mu_pt, ROOT::RVecF mu_eta, ROOT::RVecI mu_pdgId, int runP, bool hasTTHMVA){
-                        
-                        std::vector<ROOT::RVecF> SFTot;
+                       
+ 
+                        std::map<std::string, std::vector<ROOT::RVecF> > SFTot;
                         ROOT::RVecF SF;
                         ROOT::RVecF SFstat;
                         ROOT::RVecF SFsyst;
+                        
+                        ROOT::RVecF SFid;
+                        ROOT::RVecF SFid_stat;
+                        ROOT::RVecF SFid_syst;
+
+                        ROOT::RVecF SFiso;
+                        ROOT::RVecF SFiso_stat;
+                        ROOT::RVecF SFiso_syst;
+
+                        ROOT::RVecF SFtth;
+                        ROOT::RVecF SFtth_stat;
+                        ROOT::RVecF SFtth_syst;
                         
                         float sf,sfstat,sfsyst,sf_id,sf_idstat,sf_idsyst,sf_iso,sf_isostat,sf_isosyst,sf_tth,sf_tthstat,sf_tthsyst;
                         float pt,eta;
@@ -679,15 +692,48 @@ class LeptonSF(Module):
                                 SFstat.push_back(sfstat);
                                 SFsyst.push_back(sfsyst);
 
+								SFid.push_back(sf_id);
+								SFid_stat.push_back(sf_idstat);
+								SFid_syst.push_back(sf_idsyst);	
+								
+								SFiso.push_back(sf_iso);
+								SFiso_stat.push_back(sf_isostat);
+								SFiso_syst.push_back(sf_isosyst);	
+								
+								SFtth.push_back(sf_tth);
+								SFtth_stat.push_back(sf_tthstat);
+								SFtth_syst.push_back(sf_tthsyst);	
+
                             }else{
                                 SF.push_back(1.0);
                                 SFstat.push_back(0.0);
                                 SFsyst.push_back(0.0);
+								SFid.push_back(1.0);
+								SFid_stat.push_back(0.0);
+								SFid_syst.push_back(0.0);	
+								SFiso.push_back(1.0);
+								SFiso_stat.push_back(0.0);
+								SFiso_syst.push_back(0.0);	
+								SFtth.push_back(1.0);
+								SFtth_stat.push_back(0.0);
+								SFtth_syst.push_back(0.0);	
                             }
                         }
-                        SFTot.push_back(SF);
-                        SFTot.push_back(SFstat);
-                        SFTot.push_back(SFsyst);
+                        SFTot["total"].push_back(SF);
+                        SFTot["total"].push_back(SFstat);
+                        SFTot["total"].push_back(SFsyst);
+
+                        SFTot["id"].push_back(SFid);
+                        SFTot["id"].push_back(SFid_stat);
+                        SFTot["id"].push_back(SFid_syst);
+							
+                        SFTot["iso"].push_back(SFiso);
+                        SFTot["iso"].push_back(SFiso_stat);
+                        SFTot["iso"].push_back(SFiso_syst);
+                        
+						SFTot["tth"].push_back(SFtth);
+                        SFTot["tth"].push_back(SFtth_stat);
+                        SFTot["tth"].push_back(SFtth_syst);
                         return SFTot;
                     }
                 """
@@ -699,34 +745,36 @@ class LeptonSF(Module):
             )
 
             columnsToDrop.append(f"MuonSF_{wp}_tmp")
+            for item in ['total', 'id', 'iso', 'tth']:
+              appendString = 'IdIso' if item == 'total' else item
 
-            df = df.Define(f"Lepton_tightMuon_{wp}_IdIsoSF", f"MuonSF_{wp}_tmp[0]")
+              df = df.Define(f"Lepton_tightMuon_{wp}_{appendString}SF", f"MuonSF_{wp}_tmp[\"{item}\"][0]")
 
-            df = df.Define(
-                f"Lepton_tightMuon_{wp}_IdIsoSF_Up",
-                f"MuonSF_{wp}_tmp[0] + MuonSF_{wp}_tmp[1]",
-            )
+              df = df.Define(
+                f"Lepton_tightMuon_{wp}_{appendString}SF_Up",
+                f"MuonSF_{wp}_tmp[\"{item}\"][0] + MuonSF_{wp}_tmp[\"{item}\"][1]",
+              )
 
-            df = df.Define(
-                f"Lepton_tightMuon_{wp}_IdIsoSF_Down",
-                f"MuonSF_{wp}_tmp[0] - MuonSF_{wp}_tmp[1]",
-            )
+              df = df.Define(
+                f"Lepton_tightMuon_{wp}_{appendString}SF_Down",
+                f"MuonSF_{wp}_tmp[\"{item}\"][0] - MuonSF_{wp}_tmp[\"{item}\"][1]",
+              )
 
-            df = df.Define(
-                f"Lepton_tightMuon_{wp}_IdIsoSF_Syst",
-                f"MuonSF_{wp}_tmp[0] + MuonSF_{wp}_tmp[2]",
-            )
+              df = df.Define(
+                  f"Lepton_tightMuon_{wp}_{appendString}SF_Syst",
+                  f"MuonSF_{wp}_tmp[\"{item}\"][0] + MuonSF_{wp}_tmp[\"{item}\"][2]",
+              )
 
-            df = df.Define(f"Lepton_tightMuon_{wp}_TotSF", f"MuonSF_{wp}_tmp[0]")
+            df = df.Define(f"Lepton_tightMuon_{wp}_TotSF", f"MuonSF_{wp}_tmp[\"total\"][0]")
 
             df = df.Define(
                 f"Lepton_tightMuon_{wp}_TotSF_Up",
-                f"MuonSF_{wp}_tmp[0] + sqrt(MuonSF_{wp}_tmp[1]*MuonSF_{wp}_tmp[1] + MuonSF_{wp}_tmp[2]*MuonSF_{wp}_tmp[2])",
+                f"MuonSF_{wp}_tmp[\"total\"][0] + sqrt(MuonSF_{wp}_tmp[\"total\"][1]*MuonSF_{wp}_tmp[\"total\"][1] + MuonSF_{wp}_tmp[\"total\"][2]*MuonSF_{wp}_tmp[\"total\"][2])",
             )
 
             df = df.Define(
                 f"Lepton_tightMuon_{wp}_TotSF_Down",
-                f"MuonSF_{wp}_tmp[0] - sqrt(MuonSF_{wp}_tmp[1]*MuonSF_{wp}_tmp[1] + MuonSF_{wp}_tmp[2]*MuonSF_{wp}_tmp[2])",
+                f"MuonSF_{wp}_tmp[\"total\"][0] - sqrt(MuonSF_{wp}_tmp[\"total\"][1]*MuonSF_{wp}_tmp[\"total\"][1] + MuonSF_{wp}_tmp[\"total\"][2]*MuonSF_{wp}_tmp[\"total\"][2])",
             )
 
         for col in columnsToDrop:

--- a/mkShapesRDF/processor/modules/LeptonSF.py
+++ b/mkShapesRDF/processor/modules/LeptonSF.py
@@ -731,7 +731,7 @@ class LeptonSF(Module):
                         SFTot["iso"].push_back(SFiso_stat);
                         SFTot["iso"].push_back(SFiso_syst);
                         
-						SFTot["tth"].push_back(SFtth);
+                        SFTot["tth"].push_back(SFtth);
                         SFTot["tth"].push_back(SFtth_stat);
                         SFTot["tth"].push_back(SFtth_syst);
                         return SFTot;

--- a/mkShapesRDF/processor/modules/LeptonSel.py
+++ b/mkShapesRDF/processor/modules/LeptonSel.py
@@ -5,11 +5,12 @@ from mkShapesRDF.processor.framework.module import Module
 
 
 class LeptonSel(Module):
-    def __init__(self, LepFilter, nLF, era):
+    def __init__(self, LepFilter, nLF, era, filter=True):
         super().__init__("LeptonSel")
         self.era = era
         self.LepFilter = LepFilter
         self.nLF = nLF
+        self.filter = filter
 
     def runModule(self, df, values):
         Clean_Tag = LepFilter_dict[self.LepFilter]
@@ -176,8 +177,8 @@ class LeptonSel(Module):
 
 
         # TODO add VetoLeptons and dmZll
-
-        df = df.Filter("Lepton_pt[LeptonMask_minPt_pass].size() >= 1")
+        if self.filter:
+            df = df.Filter("Lepton_pt[LeptonMask_minPt_pass].size() >= 1")
 
         values.append(
             [


### PR DESCRIPTION
CAT is currently working on checking different frameworks for differences against a common source of "truth" for SF implementation.
The repository holding the tests is https://gitlab.cern.ch/cms-analysis/general/analysis_recipes
It contains a pipeline that runs every night and compares frameworks on a small sample of 10k TTBar events.
This PR provides the technical handles to allow for such test and in particular:

- Possibility to define samples that are not on DAS, but just in a directory: https://github.com/lenzip/mkShapesRDF/commit/1d1e4c9193937b873a3f230730e837adddce8c85 and https://github.com/lenzip/mkShapesRDF/commit/a296485d8954d7319cafc9b030ef1955e7627b0d
- Add a corresponding "dummy" campaign: https://github.com/lenzip/mkShapesRDF/commit/8167f6318bb7b40f0a9dc0a6024a0f51fc9dc1aa
- Add a few steps that only run, in this case, the lepton SFs: https://github.com/lenzip/mkShapesRDF/commit/3e7db6d9f2c06c1dae8619690dc7612a5881fca1
- Optionally disable filtering in LeptonSel, because the test needs to run on all events: https://github.com/lenzip/mkShapesRDF/commit/fa07bb91fa85f165857dfc0774e70fd6612fecab
- Save the Muon ID and iso SFs seperately (as there are different tests): https://github.com/lenzip/mkShapesRDF/commit/1dda5af84256882d2b6908808beec2fab184a005
- Add a POG only, noISO WP for muons, as this is the one to be tested: https://github.com/lenzip/mkShapesRDF/commit/8a22e2f067dbf7f480618ee75636fc35a3b1f2c0
- Add a script to dump the txt file with the numbers to compare: https://github.com/lenzip/mkShapesRDF/commit/8a22e2f067dbf7f480618ee75636fc35a3b1f2c0

