### PR TITLE
Correcting unexpected behaviour on the --isLatino parser argument

### DIFF
--- a/mkShapesRDF/processor/scripts/mkPostProc.py
+++ b/mkShapesRDF/processor/scripts/mkPostProc.py
@@ -60,7 +60,16 @@ def defaultParser():
 
     return parser
 
-
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+        
 def operationMode0Parser(parser=None):
     if parser is None:
         parser = argparse.ArgumentParser(add_help=False)
@@ -87,7 +96,7 @@ def operationMode0Parser(parser=None):
     parser0.add_argument(
         "-iL",
         "--isLatino",
-        type=bool,
+        type=str2bool,
         help="If the files in input follow the latino naming convention",
         required=False,
         default=True,


### PR DESCRIPTION
When you use type=bool, argparse treats the string "False" as truthy, getting converted to True. This is because any non-empty string in Python is considered truthy (including "False"), and bool("False") results in True. Thus, --isLatino cannot be set to False.

To correct this issue, adding a function to parse boolean-like strings and then pass it to argparse.