### PR TITLE
Add one-lepton skim workflows  for Run3

### DIFF
--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -121,7 +121,7 @@ Steps = {
             "leptonSF",
             "puW",
             "formulasMC",
-            "JES_modules_MC",
+            "JES_modules_reduced_MC",
             "leptonScale_mc",
             "l2Kin",
             "l3Kin",

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -124,6 +124,8 @@ Steps = {
             "JES_modules_MC",
             "leptonScale_mc",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -205,6 +207,8 @@ Steps = {
             "JES_modules_reduced_MC",
             "leptonScale_mc",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -286,6 +290,8 @@ Steps = {
             "JES_modules_reduced_MC",
             "leptonScale_mc",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -367,6 +373,8 @@ Steps = {
             "JES_modules_reduced_MC",
             "leptonScale_mc",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -446,6 +454,8 @@ Steps = {
             "JES_modules_reducedv15_MC",
             "leptonScale_mc",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -648,6 +658,8 @@ Steps = {
             "lepSel",
             "jetSelMask",
             "l2Kin",
+            "l3Kin",
+            "l4Kin",
             "trigData",
             "formulasDATA",
             "finalSnapshot_DATA",
@@ -1357,6 +1369,7 @@ Steps = {
             "jetSelMask",
             "l2Kin",
             "l3Kin",
+            "l4Kin",
             "trigData",
             "formulasDATA",
             "finalSnapshot_DATA",

--- a/mkShapesRDF/processor/framework/Steps_cfg.py
+++ b/mkShapesRDF/processor/framework/Steps_cfg.py
@@ -99,6 +99,34 @@ Steps = {
             "finalSnapshot_JES",
         ]
     },
+    "MCl1loose2022v12__MCCorr2022v12JetScaling": {
+        "isChain" : True,
+        "do4MC" : True,
+        "do4Data" : False,
+        "selection" : '"((nElectron+nMuon)>0)"',
+        "subTargets" : [
+            "leptonMaker",
+            "lepFiller_tthMVA",
+            "lepSel",
+            "jetSelMask",
+            "PromptParticlesGenVars",
+            "GenVar",
+            "GenLeptonMatch",
+            "HiggsGenVars",
+            "TopGenVars",
+            "WGammaStar",
+            "DressedLeptons",
+            "baseW",
+            "trigMC",
+            "leptonSF",
+            "puW",
+            "formulasMC",
+            "JES_modules_MC",
+            "leptonScale_mc",
+            "l2Kin",
+            "finalSnapshot_JES",
+        ]
+    },
     # 2022EE
     "DATAl2loose2022EEv12__l2loose": {
         "isChain" : True,
@@ -152,6 +180,34 @@ Steps = {
             "finalSnapshot_JES",
 	]
     },
+    "MCl1loose2022EEv12__MCCorr2022EEv12JetScaling": {
+        "isChain" : True,
+        "do4MC" : True,
+        "do4Data" : False,
+        "selection" : '"((nElectron+nMuon)>0)"',
+        "subTargets" : [
+            "leptonMaker",
+            "lepFiller_tthMVA",
+            "lepSel",
+            "jetSelMask",
+            "PromptParticlesGenVars",
+            "GenVar",
+            "GenLeptonMatch",
+            "HiggsGenVars",
+            "TopGenVars",
+            "WGammaStar",
+            "DressedLeptons",
+            "baseW",
+            "trigMC",
+            "leptonSF",
+            "puW",
+            "formulasMC",
+            "JES_modules_reduced_MC",
+            "leptonScale_mc",
+            "l2Kin",
+            "finalSnapshot_JES",
+        ]
+    },
     # 2023
     "DATAl2loose2023v12__l2loose": {
         "isChain" : True,
@@ -202,6 +258,34 @@ Steps = {
             "l2Kin",
             "l3Kin",
             "l4Kin",
+            "finalSnapshot_JES",
+        ]
+    },
+    "MCl1loose2023v12__MCCorr2023v12JetScaling": {
+        "isChain" : True,
+        "do4MC" : True,
+        "do4Data" : False,
+        "selection" : '"((nElectron+nMuon)>0)"',
+        "subTargets" : [
+            "leptonMaker",
+            "lepFiller_tthMVA",
+            "lepSel",
+            "jetSelMask",
+            "PromptParticlesGenVars",
+            "GenVar",
+            "GenLeptonMatch",
+            "HiggsGenVars",
+            "TopGenVars",
+            "WGammaStar",
+            "DressedLeptons",
+            "baseW",
+            "trigMC",
+            "leptonSF",
+            "puW",
+            "formulasMC",
+            "JES_modules_reduced_MC",
+            "leptonScale_mc",
+            "l2Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -258,6 +342,34 @@ Steps = {
             "finalSnapshot_JES",
         ]
     },
+    "MCl1loose2023BPixv12__MCCorr2023BPixv12JetScaling": {
+        "isChain" : True,
+        "do4MC" : True,
+        "do4Data" : False,
+        "selection" : '"((nElectron+nMuon)>0)"',
+        "subTargets" : [
+            "leptonMaker",
+            "lepFiller_tthMVA",
+            "lepSel",
+            "jetSelMask",
+            "PromptParticlesGenVars",
+            "GenVar",
+            "GenLeptonMatch",
+            "HiggsGenVars",
+            "TopGenVars",
+            "WGammaStar",
+            "DressedLeptons",
+            "baseW",
+            "trigMC",
+            "leptonSF",
+            "puW",
+            "formulasMC",
+            "JES_modules_reduced_MC",
+            "leptonScale_mc",
+            "l2Kin",
+            "finalSnapshot_JES",
+        ]
+    },
     # 2024
     "DATAl2loose2024v15__l2loose": {
         "isChain" : True,
@@ -306,6 +418,34 @@ Steps = {
             "l2Kin",
             "l3Kin",
             "l4Kin",
+            "finalSnapshot_JES",
+        ]
+    },
+    "MCl1loose2024v15__MCCorr2024v15__JERFrom23BPix": {
+        "isChain" : True,
+        "do4MC" : True,
+        "do4Data" : False,
+        "selection" : '"((nElectron+nMuon)>0)"',
+        "subTargets" : [
+            "leptonMaker",
+            "lepFiller_tthMVA",
+            "lepSel",
+            "jetSelMask",
+            "PromptParticlesGenVars",
+            "GenVar",
+            "GenLeptonMatch",
+            "HiggsGenVars",
+            "TopGenVars",
+            "WGammaStar",
+            "DressedLeptons",
+            "baseW",
+            "trigMC",
+            "leptonSF",
+            "puW",
+            "formulasMC",
+            "JES_modules_reducedv15_MC",
+            "leptonScale_mc",
+            "l2Kin",
             "finalSnapshot_JES",
         ]
     },
@@ -1204,6 +1344,25 @@ Steps = {
             "addTnPElectron",
         ],
     },
+
+    "DATAl1loose2024v15": {
+        "isChain": True,
+        "do4MC": False,
+        "do4Data": True,
+        "selection": '"((nElectron+nMuon)>0)"',
+        "subTargets": [
+            "lumiMask",
+            "leptonMaker",
+            "lepSel",
+            "jetSelMask",
+            "l2Kin",
+            "l3Kin",
+            "trigData",
+            "formulasDATA",
+            "finalSnapshot_DATA",
+        ],
+    },
+
     "DATAl1loose2024v15__fakeSel": {
         "isChain": True,
         "do4MC": False,
@@ -1222,6 +1381,7 @@ Steps = {
             "finalSnapshot_DATA",
         ],
     },
+
     "DATAl2loose2024v15__l2tight": {
         "isChain" : True,
         "do4MC" : False,
@@ -1243,6 +1403,7 @@ Steps = {
             "finalSnapshot_DATA",
         ],
     },
+
     "MCl2loose2024v15__addTnPMuon": {
         "isChain": True,
         "do4MC": True,


### PR DESCRIPTION
This PR organizes the missing one-lepton (l1loose) skim workflows in Steps_cfg.py for Run3 campaigns (2022, 2022EE, 2023, 2023BPix and 2024).

All one-lepton workflows  must contain at least one lepton:
`(nElectron + nMuon) > 0`

What is included:

**1.** Normal one-lepton data skims: the DATAl1loose... workflows
    - These follow the standard reconstruction and kinematic chain and produce finalSnapshot_DATA.

**2.** MC one-lepton skims: the MCl1loose... workflows:
    - These follow the equivalent MC chain and produce the corresponding MC snapshot.
    
Any comment on this is highly appreciated :)