### PR TITLE
Adding new samples: GluGluHToZZTo4L_M125, TTG, WWToLNu2Q, WWTo4Q, WZ decays, VH, WWG…

### DIFF
--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -447,6 +447,10 @@ Samples['THQ'] = {
     'nanoAOD' : '/THQ_ctcvcp_HIncl_M-125_4FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM'
 }
 
+Samples['TZQB-ZTo2L'] = {
+    'nanoAOD' : '/TZQB-Zto2L-4FS_MLL-30_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
 '''
 Samples['TWZ'] = {
     'nanoAOD' : ''

--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -6,6 +6,10 @@ Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
+Samples['GluGluHToZZTo4L_M125'] = {
+    'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
@@ -57,8 +61,16 @@ Samples['WZtoLNu2Q'] = {
     'nanoAOD' :'/WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
-Samples['WZto3LNu'] = {
-    'nanoAOD' :'/WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+Samples['WZTo2L2Q'] = {
+    'nanoAOD' : '/WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+Samples['WZtoL3Nu'] = {
+    'nanoAOD' : '/WZtoL3Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+Samples['WZTo2Q2Nu'] = {
+    'nanoAOD' : '/WZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
 #### ZZ 
@@ -91,6 +103,14 @@ Samples['ZZTo2L2Q'] = {
 
 Samples['WWTo2L2Nu'] = {
     'nanoAOD' :'/WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+Samples['WWToLNu2Q'] = {
+    'nanoAOD' :'/WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM'
+}
+
+Samples['WWTo4Q'] = {
+    'nanoAOD' :'/WWto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
 Samples['WW'] = {
@@ -127,6 +147,41 @@ Samples['ggWW_LT'] = {
 
 Samples['ggWW_TL'] = {
     'nanoAOD' :'/ggWWto2L2Nu_OS_PolarizationTL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+#Samples['WWG'] = {
+#    'nanoAOD' :''
+#}
+
+Samples['WWGtoLNu2QG'] = {
+    'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+
+##### VH
+
+Samples['WminusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM'
+}
+
+Samples['WminusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM'
+}
+
+Samples['VH-HToNon2B'] = {
+    'nanoAOD' :'/VH_HtoNonbb_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM'
+}
+
+Samples['ZH-HTo2B_ZTo2Nu'] = {
+    'nanoAOD' :'/ZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
 ##### ZGamma 
@@ -368,10 +423,24 @@ Samples['TTTT'] = {
     'nanoAOD' : '/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM'
 }
 
+###### TTG
+
+Samples['TTG_PTG-10to100'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-10to100_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v4/NANOAODSIM'
+}
+
+Samples['TTG_PTG-100to200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-100to200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM'
+}
+
+Samples['TTG_PTG-200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM'
+}
+
 ###### TXX
 
 Samples['THW'] = {
-    'nanoAOD' : '/THW_ctcvcp_HIncl_M-125_5FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM/'
+    'nanoAOD' : '/THW_ctcvcp_HIncl_M-125_5FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM'
 }
 
 Samples['THQ'] = {

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -6,6 +6,10 @@ Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+Samples['GluGluHToZZTo4L_M125'] = {
+    'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
@@ -178,6 +182,21 @@ Samples['TTTT'] = {
     'nanoAOD' : '/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+###### TTG
+
+Samples['TTG_PTG-10to100'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-10to100_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM'
+}
+
+Samples['TTG_PTG-100to200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-100to200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM'
+}
+
+Samples['TTG_PTG-200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM'
+}
+
+
 ###### TXX
 
 Samples['THW'] = {
@@ -200,10 +219,17 @@ Samples['WWTo2L2Nu'] = {
     'nanoAOD' :'/WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+Samples['WWToLNu2Q'] = {
+    'nanoAOD' :'/WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
+Samples['WWTo4Q'] = {
+    'nanoAOD' :'/WWto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
 Samples['WW'] = {
     'nanoAOD' :'/WW_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
-
 
 ##### ggWW
 
@@ -243,7 +269,6 @@ Samples['GluGlutoContintoWWtoTauNuTauNu'] = {
     'nanoAOD' :'/GluGlutoContintoWWtoTauNuTauNu_TuneCP5_13p6TeV_mcfm701-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
-
 ##### WZ
 
 Samples['WZTo3LNu'] = {
@@ -262,6 +287,17 @@ Samples['WZToLNu2Q'] = {
     'nanoAOD' :'/WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+Samples['WZTo2L2Q'] = {
+    'nanoAOD' : '/WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
+Samples['WZToL3Nu'] = {
+    'nanoAOD' : '/WZtoL3Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
+Samples['WZTo2Q2Nu'] = {
+    'nanoAOD' : '/WZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
 
 #### ZZ
 
@@ -325,6 +361,32 @@ Samples['ggWW_TL'] = {
 }
 
 
+##### VH
+
+Samples['WminusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
+Samples['WminusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM'
+}
+
+Samples['VH-HToNon2B'] = {
+    'nanoAOD' :'/VH_HtoNonbb_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM'
+}
+
+Samples['ZH-HTo2B_ZTo2Nu'] = {
+    'nanoAOD' :'/ZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
 ##### ZGamma
 
 Samples['ZG2JtoG2L2J'] = {  
@@ -384,6 +446,9 @@ Samples['ZZZ'] = {
 #    'nanoAOD' :''
 #}
 
+Samples['WWGtoLNu2QG'] = {
+    'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
 
 #### ZG
 

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -207,6 +207,10 @@ Samples['THQ'] = {
     'nanoAOD' : '/THQ_ctcvcp_HIncl_M-125_4FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM'
 }
 
+Samples['TZQB-ZTo2L'] = {
+    'nanoAOD' : '/TZQB-Zto2L-4FS_MLL-30_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
 '''
 Samples['TWZ'] = {
     'nanoAOD' : ''

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -6,6 +6,10 @@ Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 } 
 
+Samples['GluGluHToZZTo4L_M125'] = {
+    'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
@@ -49,16 +53,24 @@ Samples['WZ'] = {
     'nanoAOD' :'/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
 }
 
-#Samples['WZG'] = {
-#    'nanoAOD' :''
-#}
+Samples['WZG'] = {
+    'nanoAOD' :'/WZGtoLNuZG_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
 
 Samples['WZtoLNu2Q'] = {
     'nanoAOD' :'/WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
 }
 
-Samples['WZto3LNu'] = {
-    'nanoAOD' :'/WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+Samples['WZTo2L2Q'] = {
+    'nanoAOD' : '/WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+Samples['WZToL3Nu'] = {
+    'nanoAOD' : '/WZtoL3Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+Samples['WZTo2Q2Nu'] = {
+    'nanoAOD' : '/WZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
 #### ZZ 
@@ -93,8 +105,51 @@ Samples['WWTo2L2Nu'] = {
     'nanoAOD' :'/WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM'
 }
 
+Samples['WWToLNu2Q'] = {
+    'nanoAOD' :'/WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM'
+}
+
+Samples['WWTo4Q'] = {
+    'nanoAOD' :'/WWto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM'
+}
+
 Samples['WW'] = {
     'nanoAOD' :'/WW_TuneCP5_13p6TeV_pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+#Samples['WWG'] = {
+#    'nanoAOD' :''
+#}
+
+Samples['WWGtoLNu2QG'] = {
+    'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+
+##### VH
+
+Samples['WminusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM'
+}
+
+Samples['WminusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+Samples['VH-HToNon2B'] = {
+    'nanoAOD' :'/VH_HtoNonbb_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+Samples['ZH-HTo2B_ZTo2Nu'] = {
+    'nanoAOD' :'/ZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
 ##### ZGamma 
@@ -207,6 +262,20 @@ Samples['TTHto2B'] = {
 
 Samples['TTTT'] = {
     'nanoAOD' : '/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+###### TTG
+
+Samples['TTG_PTG-10to100'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-10to100_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+Samples['TTG_PTG-100to200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-100to200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+Samples['TTG_PTG-200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
 ###### TXX

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -288,6 +288,10 @@ Samples['THQ'] = {
     'nanoAOD' : '/THQ_ctcvcp_HIncl_M-125_4FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v4/NANOAODSIM'
 }
 
+Samples['TZQB-ZTo2L'] = {
+    'nanoAOD' : '/TZQB-Zto2L-4FS_MLL-30_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM'
+}
+
 '''
 Samples['TWZ'] = {
     'nanoAOD' : ''

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -6,6 +6,10 @@ Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 } 
 
+Samples['GluGluHToZZTo4L_M125'] = {
+    'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM'
+}
+
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
@@ -49,16 +53,24 @@ Samples['WZ'] = {
     'nanoAOD' :'/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
 }
 
-#Samples['WZG'] = {
-#    'nanoAOD' :''
-#}
+Samples['WZG'] = {
+    'nanoAOD' :'/WZGtoLNuZG_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
 
 Samples['WZtoLNu2Q'] = {
     'nanoAOD' :'/WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
 }
 
-Samples['WZto3LNu'] = {
-    'nanoAOD' :'/WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+Samples['WZTo2L2Q'] = {
+    'nanoAOD' : '/WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM'
+}
+
+Samples['WZToL3Nu'] = {
+    'nanoAOD' : '/WZtoL3Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+Samples['WZTo2Q2Nu'] = {
+    'nanoAOD' : '/WZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
 #### ZZ 
@@ -93,8 +105,50 @@ Samples['WWTo2L2Nu'] = {
     'nanoAOD' :'/WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v4/NANOAODSIM'
 }
 
+Samples['WWToLNu2Q'] = {
+    'nanoAOD' :'/WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM'
+}
+
+Samples['WWTo4Q'] = {
+    'nanoAOD' :'/WWto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v4/NANOAODSIM'
+}
+
 Samples['WW'] = {
     'nanoAOD' :'/WW_TuneCP5_13p6TeV_pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+
+#Samples['WWG'] = {
+#    'nanoAOD' :''
+#}
+
+Samples['WWGtoLNu2QG'] = {
+    'nanoAOD' : '/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+##### VH
+
+Samples['WminusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+
+Samples['WminusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+
+Samples['VH-HToNon2B'] = {
+    'nanoAOD' :'/VH_HtoNonbb_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+Samples['ZH-HTo2B_ZTo2Nu'] = {
+    'nanoAOD' :'/ZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
 ##### ZGamma 
@@ -207,6 +261,20 @@ Samples['TTHto2B'] = {
 
 Samples['TTTT'] = {
     'nanoAOD' : '/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+##### TTG
+
+Samples['TTG_PTG-10to100'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-10to100_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+Samples['TTG_PTG-100to200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-100to200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
+Samples['TTG_PTG-200'] = {
+    'nanoAOD' : '/TTG-1Jets_PTG-200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
 ###### TXX

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -287,6 +287,10 @@ Samples['THQ'] = {
     'nanoAOD' : '/THQ_ctcvcp_HIncl_M-125_4FS_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v5/NANOAODSIM'
 }
 
+Samples['TZQB-ZTo2L'] = {
+    'nanoAOD' : '/TZQB-Zto2L-4FS_MLL-30_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
 '''
 Samples['TWZ'] = {
     'nanoAOD' : ''

--- a/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
+++ b/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
@@ -279,6 +279,10 @@ Samples['THQ'] = {
     'nanoAOD' : '/THQ-4FS-ctcvcp_Par-M-125_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
+Samples['TZQB-ZTo2L'] = {
+    'nanoAOD' : '/TZQB-Zto2L-4FS_Bin-MLL-30_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-Madgraph_2_6_5_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
 '''
 Samples['TWZ'] = {
     'nanoAOD' : ''

--- a/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
+++ b/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
@@ -1,12 +1,14 @@
 Samples = {}
 
-
-
 ##### Higgs 
 
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 } 
+
+Samples['GluGluHToZZTo4L_M125'] = {
+    'nanoAOD' : '/GluGluHto2Zto4L_Par-M-125_TuneCP5_13p6TeV_powhegMINNLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
 
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
@@ -63,6 +65,14 @@ Samples['WZTo2L2Q'] = {
     'nanoAOD' :'/WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
+Samples['WZToL3Nu'] = {
+    'nanoAOD' : '/WZtoL3Nu_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+Samples['WZTo2Q2Nu'] = {
+    'nanoAOD' : '/WZto2Nu2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
 #### ZZ 
 Samples['ZZ'] = {
     'nanoAOD' :'/ZZ_TuneCP5_13p6TeV_pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
@@ -80,14 +90,52 @@ Samples['ZZTo2L2Q'] = {
     'nanoAOD' :'/ZZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
+#Samples['ZZTo4Q'] = {
+#    'nanoAOD' : ''
+#}
+
 ###### WW 
 
 Samples['WWTo2L2Nu'] = {
     'nanoAOD' :'/WWto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
+Samples['WWToLNu2Q'] = {
+    'nanoAOD' :'/WWtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+Samples['WWTo4Q'] = {
+    'nanoAOD' :'/WWto4Q_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
 Samples['WW'] = {
     'nanoAOD' :'/WW_TuneCP5_13p6TeV_pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+##### VH
+
+Samples['WminusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WminusH-WtoLNu-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WToLNu'] = {
+    'nanoAOD' :'/WplusH-WtoLNu-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+Samples['WminusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WminusH-Wto2Q-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+Samples['WplusH-HtoBB_WTo2Q'] = {
+    'nanoAOD' :'/WplusH-Wto2Q-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+#Samples['VH-HToNon2B'] = {
+#    'nanoAOD' :''
+#}
+
+Samples['ZH-HTo2B_ZTo2Nu'] = {
+    'nanoAOD' :'/ZH-Zto2Nu-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
 ##### WW EWK
@@ -152,6 +200,10 @@ Samples['ZZZ'] = {
 #    'nanoAOD' :''
 #}
 
+Samples['WWGtoLNu2QG'] = {
+    'nanoAOD' : '/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
 ##### Top 
 
 Samples['TTTo2L2Nu'] = {
@@ -202,6 +254,20 @@ Samples['TTHto2B'] = {
 Samples['TTTT'] = {
     'nanoAOD' : '/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
+
+###### TTG
+
+#Samples['TTG_PTG-10to100'] = {
+#    'nanoAOD' : ''
+#}
+#
+#Samples['TTG_PTG-100to200'] = {
+#    'nanoAOD' : ''
+#}
+#
+#Samples['TTG_PTG-200'] = {
+#    'nanoAOD' : ''
+#}
 
 ###### TXX
 

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -113,6 +113,7 @@ xs_db["TTG_PTG-200"] = ["xsec=0.13", "kfact=1.000", "ref=G"]
 ### TXX
 xs_db["THW"] = ["xsec=0.133", "kfact=1.000", "ref=G"]
 xs_db["THQ"] = ["xsec=0.744", "kfact=1.000", "ref=G"]
+xs_db["TZQB-ZTo2L"] = ["xsec=0.07968", "kfact=1.000", "ref=G"]
 #xs_db["TWZ"] = ["xsec=", "kfact=1.000", "ref="]
 
 ### WZ

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -42,11 +42,14 @@ xs_db = {}
 
 ### Higgs
 xs_db["GluGluHToWWTo2L2Nu_M125"] = ["xsec=1.17381", "kfact=1.000", "ref=E"] # 51.960*0.2152*(3*0.108)*(3*0.108)
+xs_db["GluGluHToZZTo4L_M125"] = ["xsec=0.0140", "kfact=1.000", "ref=E"] # 51.960*0.02641*(0.033632+0.033662+0.033696)**2
 xs_db["VBFHToWWTo2L2Nu_M125"]    = ["xsec=0.09187", "kfact=1.000", "ref=E"] #  4.067*0.2152*(3*0.108)*(3*0.108)
 
 ### WW
 xs_db["WW"]        = ["xsec=122.1", "kfact=1.000", "ref=A"]  # (XS(pp -> e mu ve vmu) - XS(gg -> e mu ve vmu)) / (BR(W -> mu vmu)*BR(W -> e ve)) = (1.5589-0.1497)/(0.1078*0.1071)
 xs_db["WWTo2L2Nu"] = ["xsec=12.96", "kfact=1.000", "ref=A"]  # 122.1 * 0.1086 * 0.1086 * 9
+xs_db["WWToLNu2Q"] = ["xsec=53.6", "kfact=1.000", "ref=A"]  # 122.1 * 2 * BR(W->qq) * BR(W->l nu) = 122.1 * 2 * 0.6741 * 0.3258
+xs_db["WWTo4Q"]    = ["xsec=55.5", "kfact=1.000", "ref=A"]  # 122.1 * BR(W->qq)^2 = 122.1 * 0.6741 * 0.6741
 
 xs_db["GluGlutoContintoWWtoENuENu"]     = ["xsec=0.0744", "kfact=1.000", "ref=A"]
 xs_db["GluGlutoContintoWWtoENuMuNu"]    = ["xsec=0.0749", "kfact=1.000", "ref=A"]
@@ -68,6 +71,9 @@ xs_db["ggWW_LL"]      = ["xsec=0.025",  "kfact=1.000", "ref=X"] ## 0.239
 xs_db["ggWW_TT"]      = ["xsec=0.329",  "kfact=1.000", "ref=X"] ## 3.104
 xs_db["ggWW_LT"]      = ["xsec=0.0087", "kfact=1.000", "ref=X"] ## 0.08195
 xs_db["ggWW_TL"]      = ["xsec=0.0087", "kfact=1.000", "ref=X"] ## 0.08195
+
+xs_db["WWG"]        = ["xsec=0.3959", "kfact=1.0", "ref=G"]      # inclusive WWγ
+xs_db["WWGtoLNu2QG"] = ["xsec=0.359", "kfact=1.0", "ref=G"]      # lν qq γ final state
 
 ### Top
 xs_db["TTTo2L2Nu"]                    = ["xsec=98.036", "kfact=1.000", "ref=C"] # 923.6 * (3*0.1086) * (3*0.1086)
@@ -99,17 +105,33 @@ xs_db["TTHtoNon2B"] = ["xsec=0.2398", "kfact=1.000", "ref=G"] # 0.5742 * [1 - BR
 xs_db["TTHto2B"] = ["xsec=0.3344", "kfact=1.000", "ref=G"] # 0.5742 * BR(H->bb) = 0.5742 * 0.5824 = 0.3344
 xs_db["TTTT"] = ["xsec=0.009652", "kfact=1.000", "ref=G"]
 
+### TTG
+xs_db["TTG_PTG-10to100"] = ["xsec=4.22", "kfact=1.000", "ref=G"]
+xs_db["TTG_PTG-100to200"] = ["xsec=0.41", "kfact=1.000", "ref=G"]
+xs_db["TTG_PTG-200"] = ["xsec=0.13", "kfact=1.000", "ref=G"]
+
 ### TXX
 xs_db["THW"] = ["xsec=0.133", "kfact=1.000", "ref=G"]
 xs_db["THQ"] = ["xsec=0.744", "kfact=1.000", "ref=G"]
-#xs_db["TWZ"] = ["xsec=", "kfact=1.000", "ref=C"]
+#xs_db["TWZ"] = ["xsec=", "kfact=1.000", "ref="]
 
 ### WZ
 xs_db["WZTo3LNu"]  = ["xsec=5.32",    "kfact=1.000", "ref=A"] # (XS(pp->e- e+ μ-  ̄vμ) + XS(pp->e- e+ μ+ vμ)) * 9 * BR(ZW->ll lv) / BR(ZW->ee mv)  (0.2385 + 0.3474) * 9 *  0.0036552588 / 0.0036255296
 xs_db["WZ"]        = ["xsec=53.9",    "kfact=1.000", "ref=A"] # XS(WZTo3LNu) / (3*9*BR(WZ->lv ll))
 xs_db["WZTo2L2Q"]  = ["xsec=3.67",    "kfact=1.000", "ref=A"] # XS(WZ) * 3*BR(Z->ll) * BR(W->qq)
-xs_db["WZToLNu2Q"] = ["xsec=6.44",    "kfact=1.000", "ref=X"]
+xs_db["WZToLNu2Q"] = ["xsec=11.87", "kfact=1.000", "ref=A"]  # XS(WZ) * 3* BR(W->l nu) * BR(Z->qq) = 53.9 * 0.3258 * 0.6760
+xs_db["WZToL3Nu"] = ["xsec=3.51", "kfact=1.000", "ref=A"] # 53.9 * (3*0.1086) * 0.20
+xs_db["WZTo2Q2Nu"] = ["xsec=7.26", "kfact=1.000", "ref=A"] # 53.9 * 0.6741 * 0.20
 xs_db["WZG"]       = ["xsec=0.08425", "kfact=1.000", "ref=X"]
+
+### VH
+xs_db["WminusH-HtoBB_WToLNu"] = ["xsec=0.1066", "kfact=1.000", "ref=E"]  # 0.562032 * BR(H->bb) * BR(W->l nu) = 0.562032 * 0.5824 * 0.3258
+xs_db["WplusH-HtoBB_WToLNu"]  = ["xsec=0.1669", "kfact=1.000", "ref=E"]  # 0.880114 * BR(H->bb) * BR(W->l nu) = 0.880114 * 0.5824 * 0.3258
+xs_db["WminusH-HtoBB_WTo2Q"]  = ["xsec=0.2213", "kfact=1.000", "ref=E"]  # 0.562032 * BR(H->bb) * BR(W->qq) = 0.562032 * 0.5824 * 0.6760
+xs_db["WplusH-HtoBB_WTo2Q"]   = ["xsec=0.3467", "kfact=1.000", "ref=E"]  # 0.880114 * BR(H->bb) * BR(W->qq) = 0.880114 * 0.5824 * 0.6760
+
+xs_db["VH-HToNon2B"]          = ["xsec=0.9939", "kfact=1.000", "ref=E"]  # (0.880114 + 0.562032 + 0.9361) * [1 - BR(H->bb)] = 2.378246 * (1 - 0.5824)
+xs_db["ZH-HTo2B_ZTo2Nu"]      = ["xsec=0.1090", "kfact=1.000", "ref=E"]  # 0.9361 * BR(H->bb) * BR(Z->nu nu) = 0.9361 * 0.5824 * 0.2000
 
 ### Zg
 xs_db["ZGToLLG"]     = ["xsec=1.075", "kfact=1.000", "ref=X"]


### PR DESCRIPTION
This PR introduces additional Monte Carlo datasets for the different campaigns:

The following samples are added:
- `GluGluHToZZTo4L_M125`
- `TTG`: PTG binned in 10to100, 100to200 and 200
- `TZQB`
- `WWToLNu2Q`
- `WWTo4Q`
- `WWGtoLNuG` (not the WWG inclusive sample)
- `WZToL3Nu` (also removed duplicated WZto3LNu which is duplicated for some campaigns)
- `WZTo2Q2Nu`
- `VH`: `WH` and `ZH` to 2B, `VHtoNon2B`

[ I won't be post-processing these samples straight away, but just to have them in the framework ]