### PR TITLE
Fix trigger scale factor uncertainties

### DIFF
--- a/mkShapesRDF/processor/modules/TrigMaker.py
+++ b/mkShapesRDF/processor/modules/TrigMaker.py
@@ -631,23 +631,25 @@ class TrigMaker(Module):
                 if (eff_data[0]==0.0 || eff_mc[0]==0.0){
                     return sf_unc;
                 }
+
+                float sf = eff_data[0]/eff_mc[0];
                 
-                float SF_stat_d = sqrt( (abs(eff_data[3] - eff_data[0])/eff_data[0])*(abs(eff_data[3] - eff_data[0])/eff_data[0]) + (abs(eff_mc[3]-eff_mc[0])/eff_mc[0])*(abs(eff_mc[3]-eff_mc[0])/eff_mc[0]) )*eff_data[0]/eff_mc[0];
-                float SF_stat_u = sqrt( (abs(eff_data[4] - eff_data[0])/eff_data[0])*(abs(eff_data[4] - eff_data[0])/eff_data[0]) + (abs(eff_mc[4]-eff_mc[0])/eff_mc[0])*(abs(eff_mc[4]-eff_mc[0])/eff_mc[0]) )*eff_data[0]/eff_mc[0];
+                float SF_stat_d = sqrt( (abs(eff_data[3] - eff_data[0])/eff_data[0])*(abs(eff_data[3] - eff_data[0])/eff_data[0]) + (abs(eff_mc[3]-eff_mc[0])/eff_mc[0])*(abs(eff_mc[3]-eff_mc[0])/eff_mc[0]) );
+                float SF_stat_u = sqrt( (abs(eff_data[4] - eff_data[0])/eff_data[0])*(abs(eff_data[4] - eff_data[0])/eff_data[0]) + (abs(eff_mc[4]-eff_mc[0])/eff_mc[0])*(abs(eff_mc[4]-eff_mc[0])/eff_mc[0]) );
                 
                 float SF_syst_d = 0.0;
                 float SF_syst_u = 0.0;
 
                 if (eff_mc[5]!=0.0){
-                        SF_syst_d = eff_data[5]/eff_mc[5];
+                        SF_syst_d = (sf - eff_data[5]/eff_mc[5])/sf;
                 }
 
                 if (eff_mc[6]!=0.0){
-                        SF_syst_u = eff_data[6]/eff_mc[6];
+                        SF_syst_u = (eff_data[6]/eff_mc[6] - sf)/sf;
                 }
 
-                sf_unc[0] = sqrt(SF_stat_d*SF_stat_d + SF_syst_d*SF_syst_d);
-                sf_unc[1] = sqrt(SF_stat_u*SF_stat_u + SF_syst_u*SF_syst_u);
+                sf_unc[0] = sf - sf * sqrt(SF_stat_d*SF_stat_d + SF_syst_d*SF_syst_d);
+                sf_unc[1] = sf + sf * sqrt(SF_stat_u*SF_stat_u + SF_syst_u*SF_syst_u);
                 
                 return sf_unc;
             }


### PR DESCRIPTION
Hi all, 

A bug in the `TrigMaker` module was found related to the computation of the statistical and systematic variations in the `get_sf_unc` formula. The fix is implemented in this PR, consistently summing in quadrature the statistical and systematic relative uncertainties instead.

**Validation**

A validation was performed by running the post-processing chain for 100 events.

Ratio of uncertainties before fix:

<img width="857" height="911" alt="TriggerSFWeight_1l_OLD" src="https://github.com/user-attachments/assets/d0bab73c-0e00-459d-a081-de407674ba96" />

Ratio of uncertainties after fix:

<img width="857" height="911" alt="TriggerSFWeight_1l" src="https://github.com/user-attachments/assets/019fb11d-279e-4ba6-afa1-b0c0253e3b07" />
