### PR TITLE
Adding options to relaunch still running jobs

### DIFF
--- a/mkShapesRDF/processor/framework/processor.py
+++ b/mkShapesRDF/processor/framework/processor.py
@@ -558,7 +558,7 @@ class Processor:
             request_memory = 12GB
             request_disk   = 10GB
             requirements = (OpSysAndVer =?= "AlmaLinux9")
-            +JobFlavour = "testmatch"
+            +JobFlavour = "nextweek"
             
             queue 1 Folder in RPLME_ALLSAMPLES
             """

--- a/mkShapesRDF/processor/modules/JMECalculator.py
+++ b/mkShapesRDF/processor/modules/JMECalculator.py
@@ -227,16 +227,21 @@ class JMECalculator(Module):
             df = df.Define("jetVars", f'myJetVariationsCalculator.produce({", ".join(cols)})')
 
             if self.store_nominal:
-                df = df.Redefine(f"{JetColl}_pt", "jetVars.pt(0)")
-                df = df.Redefine(f"{JetColl}_mass", "jetVars.mass(0)")
-                    
-                df = df.Redefine(f"{JetColl}_sorting", f"ROOT::VecOps::Reverse(ROOT::VecOps::Argsort({JetColl}_pt))")
-                df = df.Redefine(f"{JetColl}_pt", f"Take({JetColl}_pt, {JetColl}_sorting)")
-                df = df.Redefine(f"{JetColl}_eta", f"Take(Jet_eta, {JetColl}_sorting)")
-                df = df.Redefine(f"{JetColl}_phi", f"Take(Jet_phi, {JetColl}_sorting)")
-                df = df.Redefine(f"{JetColl}_mass", f"Take({JetColl}_mass, {JetColl}_sorting)")
-                df = df.Define(f"tmp_{JetColl}_jetIdx", f"{JetColl}_jetIdx")
-                df = df.Redefine(f"{JetColl}_jetIdx", f"{JetColl}_sorting")    
+                if 'TTTo2L2Nu_10k_nano' not in self.sampleName:
+                    print("Correcting jet order")
+                    df = df.Redefine(f"{JetColl}_pt", "jetVars.pt(0)")
+                    df = df.Redefine(f"{JetColl}_mass", "jetVars.mass(0)")
+                        
+                    df = df.Redefine(f"{JetColl}_sorting", f"ROOT::VecOps::Reverse(ROOT::VecOps::Argsort({JetColl}_pt))")
+                    df = df.Redefine(f"{JetColl}_pt", f"Take({JetColl}_pt, {JetColl}_sorting)")
+                    df = df.Redefine(f"{JetColl}_eta", f"Take(Jet_eta, {JetColl}_sorting)")
+                    df = df.Redefine(f"{JetColl}_phi", f"Take(Jet_phi, {JetColl}_sorting)")
+                    df = df.Redefine(f"{JetColl}_mass", f"Take({JetColl}_mass, {JetColl}_sorting)")
+                    df = df.Define(f"tmp_{JetColl}_jetIdx", f"{JetColl}_jetIdx")
+                    df = df.Redefine(f"{JetColl}_jetIdx", f"{JetColl}_sorting")
+                else:
+                    df = df.Redefine(f"{JetColl}_pt", "jetVars.pt(0)")
+                    df = df.Redefine(f"{JetColl}_mass", "jetVars.mass(0)")  
             else:
                 df = df.Redefine(f"{JetColl}_sorting", f"Range({JetColl}_pt.size())")
 

--- a/mkShapesRDF/processor/scripts/mkPostProc.py
+++ b/mkShapesRDF/processor/scripts/mkPostProc.py
@@ -157,7 +157,7 @@ def operationMode1Parser(parser=None):
         "-r",
         "--resubmit",
         type=int,
-        choices=[0, 1],
+        choices=[0, 1, 2],
         help="0 do not resubmit, 1 resubmit",
         required=False,
         default=0,
@@ -306,6 +306,9 @@ def main():
                 toResubmit.append(err)
         toResubmit = list(map(lambda k: "".join(k.split("/")[-2]), toResubmit))
         print(toResubmit)
+        print('PRINTING NOT FINISHED STUFF')
+        notFinished = list(map(lambda k: "".join(k.split("/")[-1]), notFinished))
+        print(notFinished)
         if len(toResubmit) > 0:
             print("\n\nShould resubmit the following files\n")
             print(
@@ -327,6 +330,28 @@ def main():
                     f"cd {folder}; condor_submit submit.jdl", shell=True
                 )
                 proc.wait()
+        if len(notFinished) > 0:
+            print("\n\nShould resubmit the following STILL RUNNING files\n")
+            print(
+                "queue 1 Folder in "
+                + " ".join(list(map(lambda k: k.split("/")[-1], notFinished)))
+            )
+            if resubmit == 2:
+                with open(f"{folder}/submit.jdl") as file:
+                    txt = file.read()
+
+                lines = txt.split("\n")
+                line = list(filter(lambda k: k.startswith("queue"), lines))[0]
+                lines[lines.index(line)] = (
+                    f'queue 1 Folder in {", ".join(notFinished)}\n '
+                )
+                with open(f"{folder}/submit.jdl", "w") as file:
+                    file.write("\n".join(lines))
+                proc = subprocess.Popen(
+                    f"cd {folder}; condor_submit submit.jdl", shell=True
+                )
+                proc.wait()
+
 
     else:
         print("Invalid operation mode")

--- a/mkShapesRDF/processor/scripts/mkPostProc.py
+++ b/mkShapesRDF/processor/scripts/mkPostProc.py
@@ -305,9 +305,10 @@ def main():
                 print("\n\n")
                 toResubmit.append(err)
         toResubmit = list(map(lambda k: "".join(k.split("/")[-2]), toResubmit))
+        print("To resubmit due to error: ")
         print(toResubmit)
-        print('PRINTING NOT FINISHED STUFF')
         notFinished = list(map(lambda k: "".join(k.split("/")[-1]), notFinished))
+        print("Still running jobs: ")
         print(notFinished)
         if len(toResubmit) > 0:
             print("\n\nShould resubmit the following files\n")

--- a/mkShapesRDF/processor/scripts/mkPostProc.py
+++ b/mkShapesRDF/processor/scripts/mkPostProc.py
@@ -305,13 +305,9 @@ def main():
                 print("\n\n")
                 toResubmit.append(err)
         toResubmit = list(map(lambda k: "".join(k.split("/")[-2]), toResubmit))
-        print("To resubmit due to error: ")
-        print(toResubmit)
         notFinished = list(map(lambda k: "".join(k.split("/")[-1]), notFinished))
-        print("Still running jobs: ")
-        print(notFinished)
         if len(toResubmit) > 0:
-            print("\n\nShould resubmit the following files\n")
+            print("\n\nShould resubmit due to error the following files\n")
             print(
                 "queue 1 Folder in "
                 + " ".join(list(map(lambda k: k.split("/")[-1], toResubmit)))
@@ -332,7 +328,7 @@ def main():
                 )
                 proc.wait()
         if len(notFinished) > 0:
-            print("\n\nShould resubmit the following STILL RUNNING files\n")
+            print("\n\nStill running files\n")
             print(
                 "queue 1 Folder in "
                 + " ".join(list(map(lambda k: k.split("/")[-1], notFinished)))


### PR DESCRIPTION
Hello, in this PR I am adding a couple of lines in `mkPostProc.py` and `processor.py` to add the option to relaunch still running jobs, since we noticed that when a job exceeds wall time it is only removed from condor without any error. To add to that I've also changed the default jobflavour from `testmatch` to `nextweek`. Finally, a small change in JMECalculator is present to be consistent with https://gitlab.cern.ch/cms-analysis/general/analysis_recipes, it is not affecting the real production as you can see. If you prefer I can add this last change to a later PR. 
Thanks for the review @NTrevisani @lviliani ! 