### PR TITLE
Add missing and available signal samples

### DIFF
--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -49,9 +49,9 @@ Samples['ttHToNonbb_M125'] = {
 Samples['GluGluHToTauTau_M125_Powheg'] = {
     'nanoAOD' : '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_powhegMiNNLO-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
-#Samples['VBFHToTauTau_M125'] = {
-#    'nanoAOD' : '' 
-#} 
+Samples['VBFHToTauTau_M125'] = {
+    'nanoAOD' : '/VBFHToTauTau_M125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-Poisson60KeepRAW_130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM' 
+} 
 
 ##### ggWW 
 

--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -2,17 +2,56 @@ Samples = {}
 
 ##### Higgs 
 
+# GGH - HWW  
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
+# GGH - HZZ
 Samples['GluGluHToZZTo4L_M125'] = {
     'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
+# VBF - HWW  
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
+
+# ZH - HWW
+Samples['ZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
+# GGZH - HWW 
+Samples['GluGluZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}  
+
+# WH - HWW 
+#Samples['HWplusJ_HToWWTo2L2Nu_WToLNu_M125'] = { 
+#    'nanoAOD' : ''  
+#}  
+#Samples['HWplusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {     
+#    'nanoAOD' : '' 
+#} 
+#Samples['HWminusJ_HToWWTo2L2Nu_WToLNu_M125'] = { 
+#    'nanoAOD' : ''
+#}  
+#Samples['HWminusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''   
+#}  
+
+# TTH - NoBB 
+Samples['ttHToNonbb_M125'] = {
+    'nanoAOD' : '/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+# HTT 
+Samples['GluGluHToTauTau_M125_Powheg'] = {
+    'nanoAOD' : '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_powhegMiNNLO-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+#Samples['VBFHToTauTau_M125'] = {
+#    'nanoAOD' : '' 
+#} 
 
 ##### ggWW 
 

--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -196,6 +196,11 @@ Samples['WWGtoLNu2QG'] = {
     'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
+##### WWewk 
+
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
 
 ##### VH
 

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -2,18 +2,57 @@ Samples = {}
 
 ##### Higgs
 
+# GGH - HWW
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+# GGH - HZZ
 Samples['GluGluHToZZTo4L_M125'] = {
     'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+# VBF - HWW
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+# ZH - HWW
+Samples['ZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
+# GGZH - HWW
+Samples['GluGluZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
+# WH - HWW
+#Samples['HWplusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWplusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+
+# TTH - NoBB
+Samples['ttHToNonbb_M125'] = {
+    'nanoAOD' : '/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v4/NANOAODSIM'
+}
+
+# HTT 
+Samples['GluGluHToTauTau_M125_Powheg'] = {
+    'nanoAOD' : '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_powhegMiNNLO-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+#Samples['VBFHToTauTau_M125'] = {
+#    'nanoAOD' : ''
+#}
 
 #### DY
 

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -50,9 +50,9 @@ Samples['ttHToNonbb_M125'] = {
 Samples['GluGluHToTauTau_M125_Powheg'] = {
     'nanoAOD' : '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_powhegMiNNLO-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
-#Samples['VBFHToTauTau_M125'] = {
-#    'nanoAOD' : ''
-#}
+Samples['VBFHToTauTau_M125'] = {
+    'nanoAOD' : '/VBFHToTauTau_M125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
 
 #### DY
 

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -312,6 +312,12 @@ Samples['GluGlutoContintoWWtoTauNuTauNu'] = {
     'nanoAOD' :'/GluGlutoContintoWWtoTauNuTauNu_TuneCP5_13p6TeV_mcfm701-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
+##### WWewk
+
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+
 ##### WZ
 
 Samples['WZTo3LNu'] = {

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -47,15 +47,15 @@ Samples['ttHToNonbb_M125'] = {
 }
 
 # HTT
-#Samples['GluGluHToTauTau_M125_Powheg'] = {
-#    'nanoAOD' : ''
-#}
+Samples['GluGluHToTauTau_M125_Powheg'] = {
+    'nanoAOD' : '/GluGluHToTauTau_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
 Samples['GluGluHToTauTau_M125_amcatnlo'] = {
     'nanoAOD': '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
-#Samples['VBFHToTauTau_M125'] = {
-#    'nanoAOD' : ''
-#} 
+Samples['VBFHToTauTau_M125'] = {
+    'nanoAOD' : '/VBFHToTauTau_M125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+} 
 
 ##### ggWW  
 

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -2,17 +2,60 @@ Samples = {}
 
 ##### Higgs 
 
+# GGH - HWW 
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 } 
 
+# GGH - HZZ 
 Samples['GluGluHToZZTo4L_M125'] = {
     'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
+# VBF - HWW
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
+
+# ZH - HWW
+Samples['ZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+# GGZH - HWW
+Samples['GluGluZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
+# WH - HWW
+#Samples['HWplusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWplusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+
+# TTH - NoBB
+Samples['ttHToNonbb_M125'] = {
+    'nanoAOD' : '/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM'
+}
+
+# HTT
+#Samples['GluGluHToTauTau_M125_Powheg'] = {
+#    'nanoAOD' : ''
+#}
+Samples['GluGluHToTauTau_M125_amcatnlo'] = {
+    'nanoAOD': '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+#Samples['VBFHToTauTau_M125'] = {
+#    'nanoAOD' : ''
+#} 
 
 ##### ggWW  
 

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -168,6 +168,11 @@ Samples['WWGtoLNu2QG'] = {
     'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
+##### WWewk
+
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
 
 ##### VH
 

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -54,9 +54,9 @@ Samples['ttHToNonbb_M125'] = {
 Samples['GluGluHToTauTau_M125_amcatnlo'] = {
     'nanoAOD': '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
 }
-#Samples['VBFHToTauTau_M125'] = {
-#    'nanoAOD' : ''
-#} 
+Samples['VBFHToTauTau_M125'] = {
+    'nanoAOD' : '/VBFHToTauTau_M125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+} 
 
 ##### ggWW  
 

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -2,17 +2,61 @@ Samples = {}
 
 ##### Higgs 
 
+# GGH - HWW
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 } 
 
+# GGH - HZZ
 Samples['GluGluHToZZTo4L_M125'] = {
     'nanoAOD' : '/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM'
 }
 
+# VBF - HWW 
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
+
+# ZH - HWW
+Samples['ZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM'
+}
+
+# GGZH - HWW
+Samples['GluGluZH_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM'
+}
+
+# WH - HWW
+#Samples['HWplusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWplusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+#    'nanoAOD' : ''
+#}
+#Samples['HWminusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+#    'nanoAOD' : ''
+#}
+
+
+# TTH - NoBB
+Samples['ttHToNonbb_M125'] = {
+    'nanoAOD' : '/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+
+# HTT
+#Samples['GluGluHToTauTau_M125_Powheg'] = {
+#    'nanoAOD' : ''
+#}
+Samples['GluGluHToTauTau_M125_amcatnlo'] = {
+    'nanoAOD': '/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM'
+}
+#Samples['VBFHToTauTau_M125'] = {
+#    'nanoAOD' : ''
+#} 
 
 ##### ggWW  
 

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -169,6 +169,12 @@ Samples['WWGtoLNu2QG'] = {
     'nanoAOD' : '/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
+##### WWewk  
+
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+
 ##### VH
 
 Samples['WminusH-HtoBB_WToLNu'] = {

--- a/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
+++ b/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
@@ -2,16 +2,74 @@ Samples = {}
 
 ##### Higgs 
 
+# GGH - HWW
 Samples['GluGluHToWWTo2L2Nu_M125'] = {
     'nanoAOD' : '/GluGluHto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 } 
 
+# GGH - HZZ
 Samples['GluGluHToZZTo4L_M125'] = {
     'nanoAOD' : '/GluGluHto2Zto4L_Par-M-125_TuneCP5_13p6TeV_powhegMINNLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
+# VBF - HWW
 Samples['VBFHToWWTo2L2Nu_M125'] = {
     'nanoAOD' :	'/VBFHto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+# ZH - HWW
+Samples['ZH_Zto2L_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH-Zto2L-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['ZH_Zto2L_Hto2Wto4Q_M125'] = {
+    'nanoAOD' : '/ZH-Zto2L-Hto2Wto4Q_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['ZH_Zto2L_Hto2WtoLNu2Q_M125'] = {
+    'nanoAOD' : '/ZH-Zto2L-Hto2WtoLNu2Q_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['ZH_Zto2Q_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/ZH-Zto2Q-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+# GGZH - HWW
+Samples['GluGluZH_Zto2L_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH-Zto2L-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['GluGluZH_Zto2L_Hto2Wto4Q_M125'] = {
+    'nanoAOD' : '/GluGluZH-Zto2L-Hto2Wto4Q_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['GluGluZH_Zto2L_Hto2WtoLNu2Q_M125'] = {
+    'nanoAOD' : '/GluGluZH-Zto2L-Hto2WtoLNu2Q_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['GluGluZH_Zto2Q_Hto2Wto2L2Nu_M125'] = {
+    'nanoAOD' : '/GluGluZH-Zto2Q-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+# WH - HWW
+Samples['HWplusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+    'nanoAOD' : '/WplusH-WtoLNu-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['HWplusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+    'nanoAOD' : '/WplusH_Wto2Q_Hto2Wto2L2Nu_M-125_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['HWminusJ_HToWWTo2L2Nu_WToLNu_M125'] = {
+    'nanoAOD' : '/WminusH-WtoLNu-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['HWminusJ_HToWWTo2L2Nu_WTo2Q_M125'] = {
+    'nanoAOD' : '/WminusH-Wto2Q-Hto2Wto2L2Nu_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-jhugen-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+# TTH - NoBB
+Samples['ttHToNonbb_M125'] = {
+    'nanoAOD' : '/TTH-HtoNon2B_Par-M-125_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+
+# HTT
+Samples['GluGluHToTauTau_M125_Powheg'] = {
+    'nanoAOD' : '/GluGluHto2Tau_Par-M-125_TuneCP5_13p6TeV_powhegMINNLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['VBFHToTauTau_M125'] = {
+    'nanoAOD' : '/VBFH-HTo2Tau_Par-M-125_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
 ##### ggWW  

--- a/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
+++ b/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
@@ -198,8 +198,9 @@ Samples['ZH-HTo2B_ZTo2Nu'] = {
 
 ##### WW EWK
 
-#Samples['WWewk'] = {
-#}
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD': '/VBS-OSWWto2L2Nu-noTop_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
 
 ##### WGamma
 

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -34,16 +34,44 @@ xs_db = {}
 # BR (Z-->ee) = 0.033632  
 # BR (Z-->mm) = 0.033662
 # BR (Z-->tt) = 0.033696
-
+# BR (Z-->qq) = 0.69911
 
 # Higgs xs at 125.38 GeV from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
 # ggH - XS = 51.96 pb
-# VBF - XS = 4.067 pb 
+# VBF - XS = 4.067 pb
+# WH  - XS = 1.442 pb
+# W+H - XS = 0.907 pb
+# W-H - XS = 0.585 pb 
+# ZH  - XS = 0.936 pb
+# ggZH - XS = (51.96/48.52) * 0.1227 = 0.1314 pb extrapolated from ggH 13 TeV to 13.6 TeV
+# ttH - XS = 0.564 pb
 
 ### Higgs
 xs_db["GluGluHToWWTo2L2Nu_M125"] = ["xsec=1.17381", "kfact=1.000", "ref=E"] # 51.960*0.2152*(3*0.108)*(3*0.108)
 xs_db["GluGluHToZZTo4L_M125"] = ["xsec=0.0140", "kfact=1.000", "ref=E"] # 51.960*0.02641*(0.033632+0.033662+0.033696)**2
 xs_db["VBFHToWWTo2L2Nu_M125"]    = ["xsec=0.09187", "kfact=1.000", "ref=E"] #  4.067*0.2152*(3*0.108)*(3*0.108)
+
+xs_db["ZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.021145", "kfact=1.000", "ref=E"] # 0.936 * 0.2152*(3*0.108)*(3*0.108) 
+xs_db["ZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.002135", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
+xs_db["ZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.009244", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741
+xs_db["ZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.004443", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)
+xs_db["ZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.030756", "kfact=1.000", "ref=E"] # 0.936 * 0.69911*0.2152*0.6741*(3*0.108)
+
+xs_db["GluGluZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.002968", "kfact=1.000", "ref=E"] # 0.1314 * 0.2152*(3*0.108)*(3*0.108)
+xs_db["GluGluZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.000299", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
+xs_db["GluGluZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.001297", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741 
+xs_db["GluGluZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.000623", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)  
+xs_db["GluGluZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.004317", "kfact=1.000", "ref=E"] # 0.1314 * 0.69911*0.2152*0.6741*(3*0.108)  
+
+xs_db["HWplusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.006638", "kfact=1.000", "ref=E"] # 0.907 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)
+xs_db["HWplusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.013812", "kfact=1.000", "ref=E"] # 0.907 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)  
+xs_db["HWminusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.004281", "kfact=1.000", "ref=E"] # 0.585 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)  
+xs_db["HWminusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.008908", "kfact=1.000", "ref=E"] # 0.585 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)
+
+xs_db["ttHToNonbb_M125"] = ["xsec=0.235526", "kfact=1.000", "ref=E"] # 0.564 * (1 - 0.5824)
+
+xs_db["GluGluHToTauTau_M125_Powheg"] = ["xsec=3.250617", "kfact=1.000", "ref=E"] # 51.960 * 0.06256
+xs_db["VBFHToTauTau_M125"] = ["xsec=0.254431", "kfact=1.000", "ref=E"] # 4.067 * 0.06256
 
 ### WW
 xs_db["WW"]        = ["xsec=122.1", "kfact=1.000", "ref=A"]  # (XS(pp -> e mu ve vmu) - XS(gg -> e mu ve vmu)) / (BR(W -> mu vmu)*BR(W -> e ve)) = (1.5589-0.1497)/(0.1078*0.1071)

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -40,10 +40,11 @@ xs_db = {}
 # ggH - XS = 51.96 pb
 # VBF - XS = 4.067 pb
 # WH  - XS = 1.442 pb
-# W+H - XS = 0.907 pb
-# W-H - XS = 0.585 pb 
-# ZH  - XS = 0.936 pb
-# ggZH - XS = (51.96/48.52) * 0.1227 = 0.1314 pb extrapolated from ggH 13 TeV to 13.6 TeV
+# W+H - XS = 0.8801 pb
+# W-H - XS = 0.5620 pb 
+# ZH  - XS = 0.9361 pb
+# qqZH - XS = 0.8014 pb
+# ggZH - XS =  0.1347 pb
 # ttH - XS = 0.564 pb
 
 ### Higgs
@@ -51,22 +52,22 @@ xs_db["GluGluHToWWTo2L2Nu_M125"] = ["xsec=1.17381", "kfact=1.000", "ref=E"] # 51
 xs_db["GluGluHToZZTo4L_M125"] = ["xsec=0.0140", "kfact=1.000", "ref=E"] # 51.960*0.02641*(0.033632+0.033662+0.033696)**2
 xs_db["VBFHToWWTo2L2Nu_M125"]    = ["xsec=0.09187", "kfact=1.000", "ref=E"] #  4.067*0.2152*(3*0.108)*(3*0.108)
 
-xs_db["ZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.021145", "kfact=1.000", "ref=E"] # 0.936 * 0.2152*(3*0.108)*(3*0.108) 
-xs_db["ZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.002135", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
-xs_db["ZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.009244", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741
-xs_db["ZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.004443", "kfact=1.000", "ref=E"] # 0.936 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)
-xs_db["ZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.030756", "kfact=1.000", "ref=E"] # 0.936 * 0.69911*0.2152*0.6741*(3*0.108)
+xs_db["ZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.018104", "kfact=1.000", "ref=E"] # 0.8014 * 0.2152*(3*0.108)*(3*0.108) 
+xs_db["ZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.001828", "kfact=1.000", "ref=E"] # 0.8014 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
+xs_db["ZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.007914", "kfact=1.000", "ref=E"] # 0.8014 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741
+xs_db["ZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.003803", "kfact=1.000", "ref=E"] # 0.8014 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)
+xs_db["ZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.026333", "kfact=1.000", "ref=E"] # 0.8014 * 0.69911*0.2152*0.6741*(3*0.108)
 
-xs_db["GluGluZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.002968", "kfact=1.000", "ref=E"] # 0.1314 * 0.2152*(3*0.108)*(3*0.108)
-xs_db["GluGluZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.000299", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
-xs_db["GluGluZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.001297", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741 
-xs_db["GluGluZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.000623", "kfact=1.000", "ref=E"] # 0.1314 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)  
-xs_db["GluGluZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.004317", "kfact=1.000", "ref=E"] # 0.1314 * 0.69911*0.2152*0.6741*(3*0.108)  
+xs_db["GluGluZH_Hto2Wto2L2Nu_M125"] = ["xsec=0.003043", "kfact=1.000", "ref=E"] # 0.1347 * 0.2152*(3*0.108)*(3*0.108)
+xs_db["GluGluZH_Zto2L_Hto2Wto2L2Nu_M125"] = ["xsec=0.000307", "kfact=1.000", "ref=E"] # 0.1347 * (0.033632+0.033662+0.033696)*0.2152*(3*0.108)*(3*0.108)
+xs_db["GluGluZH_Zto2L_Hto2Wto4Q_M125"] = ["xsec=0.0013303", "kfact=1.000", "ref=E"] # 0.1347 * (0.033632+0.033662+0.033696)*0.2152*0.6741*0.6741 
+xs_db["GluGluZH_Zto2L_Hto2WtoLNu2Q_M125"] = ["xsec=0.000639", "kfact=1.000", "ref=E"] # 0.1347 * (0.033632+0.033662+0.033696)*0.2152*0.6741*(3*0.108)  
+xs_db["GluGluZH_Zto2Q_Hto2Wto2L2Nu_M125"] = ["xsec=0.004426", "kfact=1.000", "ref=E"] # 0.1347 * 0.69911*0.2152*0.6741*(3*0.108)  
 
-xs_db["HWplusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.006638", "kfact=1.000", "ref=E"] # 0.907 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)
-xs_db["HWplusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.013812", "kfact=1.000", "ref=E"] # 0.907 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)  
-xs_db["HWminusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.004281", "kfact=1.000", "ref=E"] # 0.585 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)  
-xs_db["HWminusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.008908", "kfact=1.000", "ref=E"] # 0.585 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)
+xs_db["HWplusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.006441", "kfact=1.000", "ref=E"] # 0.8801 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)
+xs_db["HWplusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.013403", "kfact=1.000", "ref=E"] # 0.8801 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)  
+xs_db["HWminusJ_HToWWTo2L2Nu_WToLNu_M125"] = ["xsec=0.004113", "kfact=1.000", "ref=E"] # 0.5620 * (3*0.108) * 0.2152*(3*0.108)*(3*0.108)  
+xs_db["HWminusJ_HToWWTo2L2Nu_WTo2Q_M125"] = ["xsec=0.008558", "kfact=1.000", "ref=E"] # 0.5620 * 0.6741 * 0.2152*(3*0.108)*(3*0.108)
 
 xs_db["ttHToNonbb_M125"] = ["xsec=0.235526", "kfact=1.000", "ref=E"] # 0.564 * (1 - 0.5824)
 

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -11,6 +11,7 @@
 # F: https://cms-gen.gitbook.io/cms-generator-central-place/about-cross-sections
 # G: https://xsecdb-xsdb-official.app.cern.ch/xsdb/
 # H: http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2023_179_v6.pdf
+# I: https://cms-generators.docs.cern.ch/useful-tools-and-links/HowToGenXSecAnalyzer/
 #
 # X: reference unknown. Please provide a valid reference!
 
@@ -90,7 +91,7 @@ xs_db["GluGlutoContintoWWtoTauNuENu"]   = ["xsec=0.0790", "kfact=1.000", "ref=A"
 xs_db["GluGlutoContintoWWtoTauNuMuNu"]  = ["xsec=0.0795", "kfact=1.000", "ref=A"]
 xs_db["GluGlutoContintoWWtoTauNuTauNu"] = ["xsec=0.0840", "kfact=1.000", "ref=A"]
 
-xs_db["WWewk"] = ["xsec=0.3304", "kfact=1.000", "ref=G"]
+xs_db["WpWmJJ_EWK_noTop"] = ["xsec=0.1012", "kfact=1.000", "ref=I"] # GenXSecAnalyzer output: 1.012e-01 +/- 4.467e-05
 
 xs_db["WWTo2L2Nu_LL"] = ["xsec=0.488",  "kfact=1.000", "ref=X"] ## 4.598 * 9 * BR(W->lnu) * BR(W->lnu) / BR(W->lnu) = 0.1086
 xs_db["WWTo2L2Nu_TT"] = ["xsec=6.266",  "kfact=1.000", "ref=X"] ## 59.03


### PR DESCRIPTION
Adding in this PR some of the missing Higgs signal samples used in Run-2 campaigns. In general, most of them are already available, with the expection of the 22+23 WH samples that would need to be added in the future.

The cross sections are computed from the latest results provided by the LHCHWG at 13.6 TeV.

Please take a look @NTrevisani, @squinto5 