### PR TITLE
Analysis recipes and 2D unrolled templates fixes

### DIFF
--- a/mkShapesRDF/processor/modules/JMECalculator.py
+++ b/mkShapesRDF/processor/modules/JMECalculator.py
@@ -261,10 +261,17 @@ class JMECalculator(Module):
                             f"tmp_{JetColl}_pt__JES_{source}_{tag}",
                             variation_pt,
                         )
-                        df = df.Define(
-                            f"tmp_{JetColl}_pt__JES_{source}_{tag}_sorting",
-                            f"ROOT::VecOps::Reverse(ROOT::VecOps::Argsort(tmp_{JetColl}_pt__JES_{source}_{tag}))",
-                        )
+                        if 'TTTo2L2Nu_10k_nano' not in self.sampleName:
+                            df = df.Define(
+                                f"tmp_{JetColl}_pt__JES_{source}_{tag}_sorting",
+                                f"ROOT::VecOps::Reverse(ROOT::VecOps::Argsort(tmp_{JetColl}_pt__JES_{source}_{tag}))",
+                            )
+                        else:
+                            df = df.Define(
+                                f"tmp_{JetColl}_pt__JES_{source}_{tag}_sorting",
+                                f"Range({JetColl}_pt.size())",
+                            )
+
                         variations_pt.append(
                             f"Take(tmp_{JetColl}_pt__JES_{source}_{tag}, tmp_{JetColl}_pt__JES_{source}_{tag}_sorting)"
                         )

--- a/mkShapesRDF/processor/modules/JMECalculator.py
+++ b/mkShapesRDF/processor/modules/JMECalculator.py
@@ -176,7 +176,7 @@ class JMECalculator(Module):
                 jerTag = self.JER_era
                 ROOT.gROOT.ProcessLine(f"JetVariationsCalculator myJetVariationsCalculator = JetVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", {jesUnc}, {addHEM}, \"{jerTag}\", \"{jsonFileSmearingTool}\", \"{smearingTool}\", false, true, {maxDR}, {maxDPT});")
             else:
-                ROOT.gROOT.ProcessLine(f"JetVariationsCalculator myJetVariationsCalculator = JetVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", std::vector<std::string>{{}}, {addHEM}, \"\", \"\", \"\", false, true, {maxDR}, {maxDPT});")
+                ROOT.gROOT.ProcessLine(f"JetVariationsCalculator myJetVariationsCalculator = JetVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", {jesUnc}, {addHEM}, \"\", \"\", \"\", false, true, {maxDR}, {maxDPT});")
             calc = getattr(ROOT, "myJetVariationsCalculator")
             jesSources = calc.available()
             jesSources = calc.available()[1:][::2]
@@ -241,7 +241,8 @@ class JMECalculator(Module):
                     df = df.Redefine(f"{JetColl}_jetIdx", f"{JetColl}_sorting")
                 else:
                     df = df.Redefine(f"{JetColl}_pt", "jetVars.pt(0)")
-                    df = df.Redefine(f"{JetColl}_mass", "jetVars.mass(0)")  
+                    df = df.Redefine(f"{JetColl}_mass", "jetVars.mass(0)")
+                    df = df.Define(f"tmp_{JetColl}_jetIdx", f"{JetColl}_jetIdx") 
             else:
                 df = df.Redefine(f"{JetColl}_sorting", f"Range({JetColl}_pt.size())")
 

--- a/mkShapesRDF/processor/modules/JMECalculator.py
+++ b/mkShapesRDF/processor/modules/JMECalculator.py
@@ -377,7 +377,7 @@ class JMECalculator(Module):
                     isT1smearedMET  = "true"
                     ROOT.gROOT.ProcessLine(f"Type1METVariationsCalculator my{MET}VarCalc = Type1METVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", \"{L1JecTag}\", {unclEnThr}, {emEnFracThr}, {jesUnc}, {addHEM}, {isT1smearedMET}, {isXYCorrected}, \"{met_xy_json}\", \"{met_xy_era}\", {is_mc}, \"{jerTag}\", \"{jsonFileSmearingTool}\", \"{smearingTool}\", false, true, {maxDR}, {maxDPT});")
                 else:
-                    ROOT.gROOT.ProcessLine(f"Type1METVariationsCalculator my{MET}VarCalc = Type1METVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", \"{L1JecTag}\", {unclEnThr}, {emEnFracThr}, std::vector<std::string>{{}}, {addHEM}, {isT1smearedMET}, {isXYCorrected}, \"{met_xy_json}\", \"{met_xy_era}\", {is_mc}, \"\", \"\", \"\", false, true, {maxDR}, {maxDPT});")
+                    ROOT.gROOT.ProcessLine(f"Type1METVariationsCalculator my{MET}VarCalc = Type1METVariationsCalculator::create(\"{jsonFile}\", \"{jetAlgo}\", \"{jecTag}\", \"{jecLevel}\", \"{L1JecTag}\", {unclEnThr}, {emEnFracThr}, {jesUnc}, {addHEM}, {isT1smearedMET}, {isXYCorrected}, \"{met_xy_json}\", \"{met_xy_era}\", {is_mc}, \"\", \"\", \"\", false, true, {maxDR}, {maxDPT});")
                 calcMET = getattr(ROOT, f"my{MET}VarCalc")
                 METSources = calcMET.available()
                 METSources = calcMET.available()[1:][::2]

--- a/mkShapesRDF/processor/modules/TauScaleFactors.py
+++ b/mkShapesRDF/processor/modules/TauScaleFactors.py
@@ -59,16 +59,16 @@ class TauScaleFactors(Module):
 
             using namespace ROOT::VecOps;
 
-            std::vector<double> doTauMET(RVecF orig_pt, RVecF new_pt, RVecF tau_phi, double met_pt, double met_phi) {{
-                double metx = met_pt * cos(met_phi);
-                double mety = met_pt * sin(met_phi);
+            std::vector<float> doTauMET(RVecF orig_pt, RVecF new_pt, RVecF tau_phi, float met_pt, float met_phi) {{
+                float metx = met_pt * cos(met_phi);
+                float mety = met_pt * sin(met_phi);
                 for (unsigned i = 0; i < new_pt.size(); i++) {{
-                double dpt = new_pt[i] - orig_pt[i];
+                float dpt = new_pt[i] - orig_pt[i];
                 metx -= dpt * cos(tau_phi[i]);
                 mety -= dpt * sin(tau_phi[i]);
                 }}
-                double new_met_pt = sqrt(metx*metx + mety*mety);
-                double new_met_phi = atan2(mety, metx);
+                float new_met_pt = sqrt(metx*metx + mety*mety);
+                float new_met_phi = atan2(mety, metx);
                 return {{new_met_pt, new_met_phi}};
             }}
             std::cout << "doTauMET done" << std::endl;
@@ -93,10 +93,10 @@ class TauScaleFactors(Module):
                 RVecF SF(eta.size(), 1.0);
                 for (unsigned i = 0; i < eta.size(); i++) {{
                 int gm = (int)gen[i];
-                if (gm != 0 && gm != 1 && gm != 3) continue;
-                int decay = (int)dm[i];
+                if (gm != 1 && gm != 3) continue;
+                int decay = ((int)dm[i] == 2) ? 1 : (int)dm[i];
                 if (decay != 0 && decay != 1 && decay != 10 && decay != 11) continue;
-                if (pt[i] <= 20 || fabs(eta[i]) >= 2.5 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
+                if (pt[i] <= 20 || fabs(eta[i]) >= 2.3 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
                 SF[i] = tau_sfvse->evaluate({{(double)eta[i], decay, gm, "VVLoose", "nom"}});
                 }}
                 return SF;
@@ -106,9 +106,9 @@ class TauScaleFactors(Module):
                 RVecF SF(eta.size(), 1.0);
                 for (unsigned i = 0; i < eta.size(); i++) {{
                 int gm = (int)gen[i];
-                if (gm != 0 && gm != 2 && gm != 4) continue;
-                int decay = (int)dm[i];
-                if (pt[i] <= 20 || fabs(eta[i]) >= 2.5 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
+                if (gm != 2 && gm != 4) continue;
+                int decay = ((int)dm[i] == 2) ? 1 : (int)dm[i];
+                if (pt[i] <= 20 || fabs(eta[i]) >= 2.3 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
                 if (std::string("{self.era}") == "Full2024v15") {{
                     SF[i] = tau_sfvsmu->evaluate({{(double)eta[i], gm, "Medium", "VVLoose", "Medium", "nom"}});
                 }}
@@ -123,9 +123,9 @@ class TauScaleFactors(Module):
                 RVecF SF(pt.size(), 1.0);
                 for (unsigned i = 0; i < pt.size(); i++) {{
                 int gm = (int)gen[i];
-                if (gm != 0 && gm != 1 && gm != 2 && gm != 3 && gm != 4 && gm != 5 && gm != 6) continue;
-                int decay = (int)dm[i];
-                if (pt[i] <= 20 || fabs(eta[i]) >= 2.5 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
+                if (gm != 5) continue;
+                int decay = ((int)dm[i] == 2) ? 1 : (int)dm[i];
+                if (pt[i] <= 20 || fabs(eta[i]) >= 2.3 || fabs(dz[i]) >= 0.2 || decay == 5 || decay == 6) continue;
                 if (std::string("{self.era}") == "Full2024v15") {{
                     if (decay != 0 && decay != 1 && decay != 10 && decay != 11) continue;
                     SF[i] = tau_sfvsjet->evaluate({{ (double)pt[i], decay, gm, "Medium", "VVLoose", "nom", "dm"}});

--- a/mkShapesRDF/shapeAnalysis/histo_utils.py
+++ b/mkShapesRDF/shapeAnalysis/histo_utils.py
@@ -140,7 +140,7 @@ def postPlot(hTotal, doFold, unroll=True):
         stats1d[3] = stats2d[3] + stats2d[5]
         hTotal.PutStats(stats1d.GetArray())
 
-        hTotal_rolled.Delete()
+        #hTotal_rolled.Delete()
 
     if unroll and isinstance(hTotal, ROOT.TH3) and hTotal.GetDimension() == 3:
         # --- transform 2D into 1D


### PR DESCRIPTION
Hello @NTrevisani @BlancoFS, I am including some minor updates in this PR in order to perform some frameworks check in the context of the [analyisis recipes](https://gitlab.cern.ch/cms-analysis/general/analysis_recipes). 
In particular, I am modyfing:
- `JMECalculator.py`:  Small change in the inputs of JMECalculators so that the variations can be evaluated even when the smearing is off  for both jets and MET [1, 2]. Saving the unordered jet index to use for variations in the specific case of the analysis recipes tests, note the if conditions, meaning that this does not impact on our postprocessing [3]
- `TauScaleFactors.py`: General swap from double to float and refining selections
- `histo_utils.py` : remove histogram deletion [4] so that the code doesn't crashes when defining variables such as 
```
variables['mllVSmth01leq20'] = {
    'name'  : 'mll:mth',
    'range' : ([12, 25, 40, 50, 70, 90, 210],[60, 80, 90, 110, 130, 150, 200],),
    'xaxis' : 'm_{ll} : m_{T}^{H}',
    'fold'  : 3,
    'blind'   :  dict([(cut, 'full') for cut in cuts2j if 'hww_sr' in cut])
}
```
Let me know if it's all clear or if I need to produce some example files/plots.
Thanks for the review!
[1]: https://github.com/latinos/mkShapesRDF/compare/master...latinos:mkShapesRDF:squinto_dev?expand=1#diff-24cb161941ae0ff2ceaf7293ebfec5428715ff3e204de1e9be15dbf245605fc1R179
[2]: https://github.com/latinos/mkShapesRDF/compare/master...latinos:mkShapesRDF:squinto_dev?expand=1#diff-24cb161941ae0ff2ceaf7293ebfec5428715ff3e204de1e9be15dbf245605fc1R380
[3] : https://github.com/latinos/mkShapesRDF/compare/master...latinos:mkShapesRDF:squinto_dev?expand=1#diff-24cb161941ae0ff2ceaf7293ebfec5428715ff3e204de1e9be15dbf245605fc1R245-R274
[4] : https://github.com/latinos/mkShapesRDF/compare/master...latinos:mkShapesRDF:squinto_dev?expand=1#diff-e0ac8206f148e36fdfb520c74a80eacfc4f64602dc6dafc5ff1f58429f2c5bb9R143