### PR TITLE
Add Run-3 fixed WWjj Ewk Polarized samples and QCD WWjj to the postprocessing.

### DIFF
--- a/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22EE_130x_nAODv12.py
@@ -202,6 +202,38 @@ Samples['WpWmJJ_EWK_noTop'] = {
     'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
 }
 
+##### OS WW EWK + QCD + EWK polarized (all with noTop filter)
+Samples['WpWmJJ_QCD_noTop'] = {
+    'nanoAOD' : '/WWto2L2Nu-2Jets_OS_noTop_QCD_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM'
+}
+
 ##### VH
 
 Samples['WminusH-HtoBB_WToLNu'] = {

--- a/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer22_130x_nAODv12.py
@@ -312,10 +312,36 @@ Samples['GluGlutoContintoWWtoTauNuTauNu'] = {
     'nanoAOD' :'/GluGlutoContintoWWtoTauNuTauNu_TuneCP5_13p6TeV_mcfm701-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
-##### WWewk
-
+##### OS WW EWK + QCD + EWK polarized (all with noTop filter)
+Samples['WpWmJJ_QCD_noTop'] = {
+    'nanoAOD' : '/WWto2L2Nu-2Jets_OS_noTop_QCD_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
 Samples['WpWmJJ_EWK_noTop'] = {
-    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM'
 }
 
 ##### WZ

--- a/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23BPix_130x_nAODv12.py
@@ -168,11 +168,38 @@ Samples['WWGtoLNu2QG'] = {
     'nanoAOD' :'/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
 
-##### WWewk
-
-Samples['WpWmJJ_EWK_noTop'] = {
-    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+##### OS WW EWK + QCD + EWK polarized (all with noTop filter)
+Samples['WpWmJJ_QCD_noTop'] = {
+    'nanoAOD' : '/WWto2L2Nu-2Jets_OS_noTop_QCD_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
 }
+Samples['WpWmJJ_EWK_noTop'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv12-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM'
+}
+
 
 ##### VH
 

--- a/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
+++ b/mkShapesRDF/processor/framework/samples/Summer23_130x_nAODv12.py
@@ -169,10 +169,36 @@ Samples['WWGtoLNu2QG'] = {
     'nanoAOD' : '/WWGtoLNu2QG-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
-##### WWewk  
-
+##### OS WW EWK + QCD + EWK polarized (all with noTop filter)
+Samples['WpWmJJ_QCD_noTop'] = {
+    'nanoAOD' : '/WWto2L2Nu-2Jets_OS_noTop_QCD_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
 Samples['WpWmJJ_EWK_noTop'] = {
-    'nanoAOD': '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-LT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TL_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu_noTop-TT_WWCM_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv12-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM'
 }
 
 ##### VH

--- a/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
+++ b/mkShapesRDF/processor/framework/samples/Summer24_150x_nAODv15.py
@@ -196,10 +196,37 @@ Samples['ZH-HTo2B_ZTo2Nu'] = {
     'nanoAOD' :'/ZH-Zto2Nu-Hto2B_Par-M-125_TuneCP5_13p6TeV_powhegMINLO-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
-##### WW EWK
+##### OS WW EWK + QCD + EWK polarized (all with noTop filter)
 
+Samples['WpWmJJ_QCD_noTop'] = {
+    'nanoAOD' : '/WWJJto2L2Nu-OS-noTop-QCD_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
 Samples['WpWmJJ_EWK_noTop'] = {
-    'nanoAOD': '/VBS-OSWWto2L2Nu-noTop_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'    
+}
+Samples['WpWmJJ_EWK_noTop_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-LL_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-LT_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-TL_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-TT_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-LL-WWCM_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_LT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-LT-WWCM_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TL'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-TL-WWCM_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
+}
+Samples['WpWmJJ_EWK_noTop_CMWW_pol_TT'] = {
+    'nanoAOD' : '/VBS-OSWWto2L2Nu-noTop-TT-WWCM_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM'
 }
 
 ##### WGamma

--- a/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
+++ b/mkShapesRDF/processor/framework/samples/samplesCrossSections_13p6TeV.py
@@ -12,7 +12,6 @@
 # G: https://xsecdb-xsdb-official.app.cern.ch/xsdb/
 # H: http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2023_179_v6.pdf
 # I: https://cms-generators.docs.cern.ch/useful-tools-and-links/HowToGenXSecAnalyzer/
-#
 # X: reference unknown. Please provide a valid reference!
 
 xs_db = {}
@@ -92,6 +91,17 @@ xs_db["GluGlutoContintoWWtoTauNuMuNu"]  = ["xsec=0.0795", "kfact=1.000", "ref=A"
 xs_db["GluGlutoContintoWWtoTauNuTauNu"] = ["xsec=0.0840", "kfact=1.000", "ref=A"]
 
 xs_db["WpWmJJ_EWK_noTop"] = ["xsec=0.1012", "kfact=1.000", "ref=I"] # GenXSecAnalyzer output: 1.012e-01 +/- 4.467e-05
+
+xs_db["WpWmJJ_EWK_noTop"] = ["xsec=0.101", "kfact=1.000", "ref=I"] #inclusive in polarization
+xs_db["WpWmJJ_EWK_noTop_pol_LL"] = ["xsec=0.005605", "kfact=1.000", "ref=I"] #also cross-checked by calculating the quantity of XS(pp -> W{0}W{0}jj)*(3*BR(W -> lnu))^2
+xs_db["WpWmJJ_EWK_noTop_pol_LT"] = ["xsec=0.01684", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_pol_TL"] = ["xsec=0.01767", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_pol_TT"] = ["xsec=0.05965", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_CMWW_pol_LL"] = ["xsec=0.00757", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_CMWW_pol_LT"] = ["xsec=0.01589", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_CMWW_pol_TL"] = ["xsec=0.01679", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_EWK_noTop_CMWW_pol_TT"] = ["xsec=0.05956", "kfact=1.000", "ref=I"]
+xs_db["WpWmJJ_QCD_noTop"] = ["xsec=2.675", "kfact=1.000", "ref=I"]
 
 xs_db["WWTo2L2Nu_LL"] = ["xsec=0.488",  "kfact=1.000", "ref=X"] ## 4.598 * 9 * BR(W->lnu) * BR(W->lnu) / BR(W->lnu) = 0.1086
 xs_db["WWTo2L2Nu_TT"] = ["xsec=6.266",  "kfact=1.000", "ref=X"] ## 59.03


### PR DESCRIPTION
This commit adds the following missing MG5 samples to the mkShapesRDF Run-3 postprocessing campaign: 
- VBS OS WWjj process inclusive in polarization
- polarized VBS OS WWjj samples with ME computed in CM of WW system as well as the system of incoming partons
- QCD WWjj samples

QCD samples were omitted in the latest postprocessing with mkShapesRD tag:Run3_production_2022_2024_jetfix.
EWK samples were missing centrally due to the MG5 bug and were recently produced after fixing the bug. 

All samples were postprocessed prior to this PR using tag:Run3_production_2022_2024_jetfix to match the latest Run-3 postprocessing campaign. Corresponding xsections were computed using GenXSecAnalyzer. 